### PR TITLE
feat: Add combine redshift catalogs pipeline config

### DIFF
--- a/combine_redshift_dedup/config.py
+++ b/combine_redshift_dedup/config.py
@@ -1,0 +1,99 @@
+import os
+from typing import Any
+
+from pydantic import BaseModel, model_validator
+
+DATASETS_DIR = os.getenv("DATASETS_DIR", "/datasets")
+
+
+class Slurm(BaseModel):
+
+    class Instance(BaseModel):
+        cores: int = 54
+        processes: int = 1
+        memory: str = "123GiB"
+        queue: str = "cpu"
+        job_extra_directives: list[str] = ["--propagate", "--time=2:00:00"]
+
+    class Adapt(BaseModel):
+        maximum_jobs: int = 10
+
+    instance: Instance = Instance()
+    adapt: Adapt = Adapt()
+
+
+class Local(BaseModel):
+    n_workers: int = 2
+    threads_per_worker: int = 2
+    memory_limit: str = "1GiB"
+
+
+class Executor(BaseModel):
+
+    name: str = "local"
+    args: Any = {}
+
+    @model_validator(mode="before")
+    @classmethod
+    def sync_args(cls, data: Any) -> Any:
+
+        assert isinstance(data, dict), "data is not dict"
+        name = data.get("name", "local")
+
+        match name:
+            case "local":
+                executor = Local(**data.get("args", {}))
+            case "slurm":
+                executor = Slurm(**data.get("args", {}))
+            case _:
+                raise ValueError(f"name '{name}' do not match")
+
+        data["args"] = executor.model_dump()
+        return data
+
+
+class Inputs(BaseModel):
+
+    class Specz(BaseModel):
+
+        class Columns(BaseModel):
+            id: str | None = None
+            ra: str = "ra"
+            dec: str = "dec"
+            z: str = "z"
+            z_flag: str | None = None
+            z_err: str | None = None
+            survey: str | None = None
+
+        path: str = f"{DATASETS_DIR}/specz.parquet"
+        internal_name: str = "00_specz"
+        format: str = "parquet"
+        columns: Columns = Columns()
+
+    specz: list = [Specz(), Specz()]
+
+
+class Param(BaseModel):
+    combine_type: str = "concatenate"
+    flags_translation_file: str = "flags_translation.yaml"
+
+
+class Config(BaseModel):
+    output_root_dir: str = "."
+    output_dir: str = "outputs"
+    output_format: str | None = "parquet"
+    output_name: str = "crd"
+    executor: Executor = Executor()
+    inputs: Inputs = Inputs()
+    param: Param = Param()
+
+
+if __name__ == "__main__":
+    import yaml
+
+    cfg = Config()
+
+    with open("config.yml", "w") as outfile:
+        data_json = cfg.model_dump()
+        print(data_json)
+        yaml.dump(data_json, outfile)


### PR DESCRIPTION
This commit introduces the configuration file for the combine redshift catalogs pipeline with deduplication option.

The configuration is defined using pydantic models for:
- Executor: Defines the execution environment (local or slurm) and its parameters.
- Inputs: Specifies the input datasets, including paths, formats, and column mappings.
- Param: Defines pipeline parameters such as combine type and flags translation file.
- Config: Combines all the above configurations into a single object.

A default configuration file (config.yml) is generated when the script is run directly.