### PR TITLE
Fix: Update slurm config for training set maker and combine redshift …

### DIFF
--- a/combine_redshift_dedup/config.py
+++ b/combine_redshift_dedup/config.py
@@ -9,17 +9,18 @@ DATASETS_DIR = os.getenv("DATASETS_DIR", "/datasets")
 class Slurm(BaseModel):
 
     class Instance(BaseModel):
-        cores: int = 54
+        cores: int = 25
         processes: int = 1
-        memory: str = "123GiB"
-        queue: str = "cpu"
+        memory: str = "50GB"
+        queue: str = "lsst_cpu"
+        account: str = "hpc-lsst"
         job_extra_directives: list[str] = ["--propagate", "--time=2:00:00"]
 
-    class Adapt(BaseModel):
-        maximum_jobs: int = 10
+    class Scale(BaseModel):
+        jobs: int = 10
 
     instance: Instance = Instance()
-    adapt: Adapt = Adapt()
+    scale: Scale = Scale()
 
 
 class Local(BaseModel):

--- a/combine_redshift_dedup/config.template.yaml
+++ b/combine_redshift_dedup/config.template.yaml
@@ -3,19 +3,20 @@
 # http://docs.ansible.com/ansible/latest/YAMLSyntax.html
 # More general reference: http://www.yaml.org/spec/1.2/spec.html
 
-executor: 
-  name: "slurm"  # Name of the job scheduler
+executor:
+  name: "slurm" # Name of the job scheduler
   args:
     instance:
-      cores: 25         # Number of cores per job
-      processes: 1      # Number of processes per job
-      memory: "50GB"   # Memory allocated per job
-      queue: "cpu"      # Queue name
-      job_extra_directives:  # Extra directives for Slurm
+      cores: 25 # Number of cores per job
+      processes: 1 # Number of processes per job
+      memory: "50GB" # Memory allocated per job
+      queue: "lsst_cpu" # Queue name
+      account: "hpc-lsst"
+      job_extra_directives: # Extra directives for Slurm
         - "--propagate"
         - "--time=2:00:00"
     scale:
-      jobs: 10  # Fixed number of dask jobs
+      jobs: 10 # Fixed number of dask jobs
 
 inputs:
   specz:
@@ -146,10 +147,10 @@ inputs:
         survey: "survey_name"
 
 output_root_dir: "process001"
-output_dir: "outputs"     # Relative directory for final outputs
-output_name: "crd"        # Name prefix for the final output files
-output_format: "parquet"  # Output format: csv, parquet, hdf5, or fits
+output_dir: "outputs" # Relative directory for final outputs
+output_name: "crd" # Name prefix for the final output files
+output_format: "parquet" # Output format: csv, parquet, hdf5, or fits
 
 param:
-    combine_type: "concatenate_and_mark_duplicates"  # Options: "concatenate", "concatenate_and_mark_duplicates", or "concatenate_and_remove_duplicates"
-    flags_translation_file: flags_translation.yaml   # File with homogenization rules for z_flag and type
+  combine_type: "concatenate_and_mark_duplicates" # Options: "concatenate", "concatenate_and_mark_duplicates", or "concatenate_and_remove_duplicates"
+  flags_translation_file: flags_translation.yaml # File with homogenization rules for z_flag and type

--- a/training_set_maker/config.py
+++ b/training_set_maker/config.py
@@ -9,10 +9,11 @@ DATASETS_DIR = os.getenv("DATASETS_DIR", "/datasets")
 class Slurm(BaseModel):
 
     class Instance(BaseModel):
-        cores: int = 54
+        cores: int = 20
         processes: int = 1
-        memory: str = "123GiB"
-        queue: str = "cpu"
+        memory: str = "50GB"
+        queue: str = "lsst_cpu"
+        account: str = "hpc-lsst"
         job_extra_directives: list[str] = ["--propagate", "--time=2:00:00"]
 
     class Adapt(BaseModel):


### PR DESCRIPTION
…dedup

This commit updates the Slurm configuration for both the training set maker and combine redshift dedup pipelines.

The changes include:

- Reduced the number of cores for training set maker from 54 to 20 and for combine redshift dedup from 54 to 25.
- Reduced the memory for both pipelines from 123GiB to 50GB.
- Changed the queue for both pipelines from "cpu" to "lsst_cpu".
- Added the "account" parameter with the value "hpc-lsst" for both pipelines.
- Renamed `Adapt` to `Scale` in combine redshift dedup config.