### PR TITLE
Fixing hats version to avoid incompatibilities in environment

### DIFF
--- a/training_set_maker/environment.yaml
+++ b/training_set_maker/environment.yaml
@@ -11,5 +11,6 @@ dependencies:
       - distributed==2025.7.0
       - dask-jobqueue==0.9.0
       - lsdb==0.6.4
+      - hats==0.6.4
       - tables_io==1.0.0
       - h5py==3.14.0


### PR DESCRIPTION
Se só fixarmos o lsdb na versão 0.6.4, ele vai puxar o hats 0.6.5 (nova versão), aí o ambiente quebra. Fixar a versão do hats também corrige o problema.