### PR TITLE
fix: stabilize distributed crossmatch execution

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,7 +10,6 @@ DASK_EXECUTOR = os.getenv("DASK_EXECUTOR", "local")
 
 
 class Slurm(BaseModel):
-
     class Instance(BaseModel):
         cores: int = 2
         processes: int = 1
@@ -20,8 +19,9 @@ class Slurm(BaseModel):
         job_extra_directives: list[str] = ["--propagate", "--time=04:00:00"]
 
     class Scale(BaseModel):
-        minimum_jobs: int = 7
+        minimum_jobs: int = 15
         maximum_jobs: int = 15
+        adaptive: bool = False
 
     instance: Instance = Instance()
     scale: Scale = Scale()
@@ -34,7 +34,6 @@ class Local(BaseModel):
 
 
 class Executor(BaseModel):
-
     name: str = DASK_EXECUTOR
     args: Any = {}
 
@@ -58,9 +57,7 @@ class Executor(BaseModel):
 
 
 class Inputs(BaseModel):
-
     class Specz(BaseModel):
-
         class Columns(BaseModel):
             id: str | None = None
             ra: str = "ra"

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -23,8 +23,9 @@ executor:
 #        - "--propagate"
 #        - "--time=2:00:00"
 #    scale:
-#      minimum_jobs: 7
+#      minimum_jobs: 15
 #      maximum_jobs: 15
+#      adaptive: false
 
 inputs:
   specz:

--- a/packages/crossmatch_auto.py
+++ b/packages/crossmatch_auto.py
@@ -32,6 +32,7 @@ import pandas as pd
 # -----------------------
 from specz import DTYPE_STR  # Arrow-backed string dtype
 from crossmatch_diagnostics import (
+    compute_projected_pairs,
     log_component_size_diagnostics,
     log_neighbor_count_diagnostics,
     log_pair_separation_diagnostics,
@@ -288,7 +289,7 @@ def _self_xmatch_pairs(
         pair_cols.append("_dist_arcsec")
     if total_by_source is not None and "sourceleft" in xmatched.columns:
         pair_cols.append("sourceleft")
-    pairs_df = xmatched[pair_cols].compute()
+    pairs_df = compute_projected_pairs(xmatched._ddf, pair_cols)
     if len(pairs_df) == 0:
         logger.info("Self-crossmatch: no pairs found; `compared_to` remains unchanged.")
         return {}

--- a/packages/crossmatch_cross.py
+++ b/packages/crossmatch_cross.py
@@ -48,6 +48,7 @@ import dask.dataframe as dd
 # -----------------------
 from utils import get_phase_logger
 from crossmatch_diagnostics import (
+    compute_projected_pairs,
     log_component_size_diagnostics,
     log_neighbor_count_diagnostics,
     log_pair_separation_diagnostics,
@@ -848,7 +849,7 @@ def crossmatch_tiebreak(
         pair_cols.append("_dist_arcsec")
     if saturation_enabled and "sourceleft" in xmatched._ddf.columns:
         pair_cols.append("sourceleft")
-    pairs_df = xmatched._ddf[pair_cols].compute()
+    pairs_df = compute_projected_pairs(xmatched._ddf, pair_cols)
     if len(pairs_df) == 0:
         pairs_adj: Dict[str, Set[str]] = {}
         logger.info("No pairs found; `compared_to` remains unchanged.")

--- a/packages/crossmatch_diagnostics.py
+++ b/packages/crossmatch_diagnostics.py
@@ -9,6 +9,36 @@ import numpy as np
 import pandas as pd
 
 
+def _project_pairs_partition(part, columns: list[str]) -> pd.DataFrame:
+    """Return only pair columns as a plain pandas frame.
+
+    LSDB partitions are ``NestedFrame`` instances.  Returning one of those from
+    a distributed ``compute`` can make Distributed pickle every crossmatch
+    column, even after a lazy column selection.  Materializing the projection
+    inside the worker keeps the transfer narrow and avoids NestedFrame
+    serialization.
+    """
+    projected = part.loc[:, columns]
+    return pd.DataFrame(
+        {column: projected[column] for column in columns},
+        index=projected.index,
+    )
+
+
+def compute_projected_pairs(ddf, columns: list[str]) -> pd.DataFrame:
+    """Compute a worker-side pair projection and return a plain pandas frame."""
+    meta = _project_pairs_partition(ddf._meta, columns).iloc[:0]
+    projected = ddf.map_partitions(
+        _project_pairs_partition,
+        columns,
+        meta=meta,
+    )
+    result = projected.compute()
+    if type(result) is not pd.DataFrame:
+        result = pd.DataFrame(result)
+    return result
+
+
 def log_pair_separation_diagnostics(
     pairs: pd.DataFrame,
     *,

--- a/packages/executor.py
+++ b/packages/executor.py
@@ -46,7 +46,7 @@ def get_executor(executor_config: Dict[str, Any], logs_dir: str | None = None):
       - Local: start a LocalCluster(**args).
       - SLURM: start SLURMCluster with n_workers = minimum_jobs * processes.
         Each job will use the provided cores, processes, and memory.
-        Optionally enable adapt() with maximum_jobs.
+        Optionally enable adapt() when scale.adaptive is true.
 
     Args:
         executor_config: Dictionary with:
@@ -58,6 +58,7 @@ def get_executor(executor_config: Dict[str, Any], logs_dir: str | None = None):
                   - scale:
                       * minimum_jobs (int)
                       * maximum_jobs (int)
+                      * adaptive (bool, default false)
         logs_dir: Directory to store SLURM job logs (if provided).
 
     Returns:
@@ -104,6 +105,7 @@ def get_executor(executor_config: Dict[str, Any], logs_dir: str | None = None):
 
         min_jobs = int(scale_cfg.get("minimum_jobs", 0))
         max_jobs = int(scale_cfg.get("maximum_jobs", 0) or 0)
+        adaptive = bool(scale_cfg.get("adaptive", False))
 
         # n_workers in SLURMCluster = total worker processes
         n_workers_init = min_jobs * processes
@@ -126,10 +128,18 @@ def get_executor(executor_config: Dict[str, Any], logs_dir: str | None = None):
         cluster = SLURMCluster(n_workers=n_workers_init, **instance_cfg)
         logger.info("SLURMCluster started with instance args=%s", instance_cfg)
 
-        # Optional: cap number of jobs adaptively
-        if max_jobs > 0:
+        # Adaptive SLURM scaling can thrash on this pipeline because its task
+        # graph alternates between driver-heavy and worker-heavy stages. Keep a
+        # stable allocation unless adaptive scaling is explicitly requested.
+        if adaptive and max_jobs > 0:
             cluster.adapt(minimum_jobs=min_jobs, maximum_jobs=max_jobs)
-            logger.info("Adaptive ceiling enabled: maximum_jobs=%d", max_jobs)
+            logger.info(
+                "Adaptive scaling enabled: minimum_jobs=%d maximum_jobs=%d",
+                min_jobs,
+                max_jobs,
+            )
+        else:
+            logger.info("Fixed SLURM allocation enabled: jobs=%d", min_jobs)
 
         return cluster
 

--- a/tests/test_crossmatch_diagnostics.py
+++ b/tests/test_crossmatch_diagnostics.py
@@ -2,10 +2,12 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import dask.dataframe as dd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "packages"))
 
 from crossmatch_diagnostics import (  # noqa: E402
+    compute_projected_pairs,
     log_component_size_diagnostics,
     log_neighbor_count_diagnostics,
     log_pair_separation_diagnostics,
@@ -18,6 +20,29 @@ class RecordingLogger:
 
     def info(self, *args):
         self.info_calls.append(args)
+
+
+def test_compute_projected_pairs_transfers_only_requested_plain_columns():
+    source = dd.from_pandas(
+        pd.DataFrame(
+            {
+                "CRD_IDleft": ["A", "B"],
+                "CRD_IDright": ["C", "D"],
+                "sourceleft": ["one", "two"],
+                "large_unused_column": ["x" * 100, "y" * 100],
+            }
+        ),
+        npartitions=2,
+    )
+
+    result = compute_projected_pairs(
+        source,
+        ["CRD_IDleft", "CRD_IDright", "sourceleft"],
+    )
+
+    assert type(result) is pd.DataFrame
+    assert result.columns.tolist() == ["CRD_IDleft", "CRD_IDright", "sourceleft"]
+    assert result["CRD_IDleft"].tolist() == ["A", "B"]
 
 
 def test_pair_diagnostics_exclude_self_matches_and_log_radius_fractions():

--- a/tests/test_executor_scaling.py
+++ b/tests/test_executor_scaling.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "packages"))
+
+import executor  # noqa: E402
+
+
+class FakeSlurmCluster:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.adapt_calls = []
+
+    def adapt(self, **kwargs):
+        self.adapt_calls.append(kwargs)
+
+
+def test_slurm_executor_uses_fixed_allocation_by_default(monkeypatch):
+    monkeypatch.setattr(executor, "SLURMCluster", FakeSlurmCluster)
+
+    cluster = executor.get_executor(
+        {
+            "name": "slurm",
+            "args": {
+                "instance": {"cores": 2, "processes": 1, "memory": "30GB"},
+                "scale": {"minimum_jobs": 14, "maximum_jobs": 14},
+            },
+        }
+    )
+
+    assert cluster.kwargs["n_workers"] == 14
+    assert cluster.adapt_calls == []
+
+
+def test_slurm_executor_enables_adaptive_scaling_only_explicitly(monkeypatch):
+    monkeypatch.setattr(executor, "SLURMCluster", FakeSlurmCluster)
+
+    cluster = executor.get_executor(
+        {
+            "name": "slurm",
+            "args": {
+                "instance": {"cores": 2, "processes": 1, "memory": "30GB"},
+                "scale": {
+                    "minimum_jobs": 7,
+                    "maximum_jobs": 15,
+                    "adaptive": True,
+                },
+            },
+        }
+    )
+
+    assert cluster.adapt_calls == [{"minimum_jobs": 7, "maximum_jobs": 15}]


### PR DESCRIPTION
- project pair columns inside workers before collection
- convert NestedFrame partitions to narrow pandas DataFrames
- avoid serializing complete crossmatch partitions
- use a fixed 15-worker SLURM allocation by default
- require explicit opt-in for adaptive scaling
- add tests for pair projection and executor scaling