### PR TITLE
fix: prevent wide NestedFrame serialization in crossmatch

### DIFF
--- a/packages/crossmatch_auto.py
+++ b/packages/crossmatch_auto.py
@@ -36,6 +36,7 @@ from crossmatch_diagnostics import (
     log_component_size_diagnostics,
     log_neighbor_count_diagnostics,
     log_pair_separation_diagnostics,
+    project_catalog_for_pair_crossmatch,
 )
 from utils import get_phase_logger
 
@@ -277,8 +278,12 @@ def _self_xmatch_pairs(
         radius_arcsec,
         n_neighbors,
     )
-    xmatched = catalog.crossmatch(
+    pair_catalog = project_catalog_for_pair_crossmatch(
         catalog,
+        include_source=total_by_source is not None,
+    )
+    xmatched = pair_catalog.crossmatch(
+        pair_catalog,
         radius_arcsec=radius_arcsec,
         n_neighbors=n_neighbors,
         suffixes=("left", "right"),

--- a/packages/crossmatch_cross.py
+++ b/packages/crossmatch_cross.py
@@ -52,6 +52,7 @@ from crossmatch_diagnostics import (
     log_component_size_diagnostics,
     log_neighbor_count_diagnostics,
     log_pair_separation_diagnostics,
+    project_catalog_for_pair_crossmatch,
 )
 from specz import (
     _build_collection_with_retry,
@@ -833,8 +834,16 @@ def crossmatch_tiebreak(
 
     # 1) Spatial crossmatch
     t0 = time.time()
-    xmatched = left_cat.crossmatch(
+    pair_left = project_catalog_for_pair_crossmatch(
+        left_cat,
+        include_source=saturation_enabled,
+    )
+    pair_right = project_catalog_for_pair_crossmatch(
         right_cat,
+        include_source=False,
+    )
+    xmatched = pair_left.crossmatch(
+        pair_right,
         radius_arcsec=radius,
         n_neighbors=k,
         suffixes=("left", "right"),

--- a/packages/crossmatch_diagnostics.py
+++ b/packages/crossmatch_diagnostics.py
@@ -9,6 +9,31 @@ import numpy as np
 import pandas as pd
 
 
+def project_catalog_for_pair_crossmatch(catalog, *, include_source: bool):
+    """Return a narrow LSDB catalog, preserving its projected margin.
+
+    LSDB crossmatch outputs include every input column.  Projecting only after
+    the crossmatch is too late for very large partitions because Distributed
+    may need to serialize the wide ``NestedFrame`` dependency first.  Narrowing
+    both the main catalog and its margin here prevents that wide result from
+    being created at all.
+    """
+    required = ["CRD_ID", "ra", "dec"]
+    if include_source and "source" in catalog.columns:
+        required.append("source")
+
+    missing = [column for column in required if column not in catalog.columns]
+    if missing:
+        raise KeyError(f"Crossmatch pair projection is missing columns: {missing}")
+
+    projected = catalog[required]
+    margin = getattr(catalog, "margin", None)
+    if margin is not None:
+        margin_columns = [column for column in required if column in margin.columns]
+        projected.margin = margin[margin_columns]
+    return projected
+
+
 def _project_pairs_partition(part, columns: list[str]) -> pd.DataFrame:
     """Return only pair columns as a plain pandas frame.
 

--- a/tests/test_crossmatch_diagnostics.py
+++ b/tests/test_crossmatch_diagnostics.py
@@ -11,6 +11,7 @@ from crossmatch_diagnostics import (  # noqa: E402
     log_component_size_diagnostics,
     log_neighbor_count_diagnostics,
     log_pair_separation_diagnostics,
+    project_catalog_for_pair_crossmatch,
 )
 
 
@@ -20,6 +21,34 @@ class RecordingLogger:
 
     def info(self, *args):
         self.info_calls.append(args)
+
+
+class FakeCatalog:
+    def __init__(self, frame, margin=None):
+        self.frame = frame
+        self.columns = frame.columns
+        self.margin = margin
+
+    def __getitem__(self, columns):
+        return FakeCatalog(self.frame.loc[:, columns].copy())
+
+
+def test_pair_catalog_projection_is_narrow_and_preserves_margin():
+    frame = pd.DataFrame(
+        {
+            "CRD_ID": ["A"],
+            "ra": [1.0],
+            "dec": [2.0],
+            "source": ["survey"],
+            "unused": ["large"],
+        }
+    )
+    catalog = FakeCatalog(frame, margin=FakeCatalog(frame.copy()))
+
+    projected = project_catalog_for_pair_crossmatch(catalog, include_source=True)
+
+    assert projected.columns.tolist() == ["CRD_ID", "ra", "dec", "source"]
+    assert projected.margin.columns.tolist() == ["CRD_ID", "ra", "dec", "source"]
 
 
 def test_compute_projected_pairs_transfers_only_requested_plain_columns():

--- a/tests/test_executor_scaling.py
+++ b/tests/test_executor_scaling.py
@@ -23,12 +23,12 @@ def test_slurm_executor_uses_fixed_allocation_by_default(monkeypatch):
             "name": "slurm",
             "args": {
                 "instance": {"cores": 2, "processes": 1, "memory": "30GB"},
-                "scale": {"minimum_jobs": 14, "maximum_jobs": 14},
+                "scale": {"minimum_jobs": 15, "maximum_jobs": 15},
             },
         }
     )
 
-    assert cluster.kwargs["n_workers"] == 14
+    assert cluster.kwargs["n_workers"] == 15
     assert cluster.adapt_calls == []
 
 


### PR DESCRIPTION
- project catalogs before running LSDB crossmatches
- preserve narrow HATS margins during projection
- transfer only columns required for pair construction
- prevent Arrow failures on large crossmatch partitions
- keep a fixed allocation of 15 SLURM workers
- add regression tests for catalog projection and worker scaling