### PR TITLE
Tune adaptive SLURM scaling for higher parallelism

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,14 +13,14 @@ class Slurm(BaseModel):
     class Instance(BaseModel):
         cores: int = 2
         processes: int = 1
-        memory: str = "40GB"
+        memory: str = "20GB"
         queue: str = "cpu_pipelines"
         account: str = "hpc-pipelines"
         job_extra_directives: list[str] = ["--propagate", "--time=12:00:00"]
 
     class Scale(BaseModel):
-        minimum_jobs: int = 11
-        maximum_jobs: int = 11
+        minimum_jobs: int = 10
+        maximum_jobs: int = 22
         worker_recovery_timeout_seconds: float = 600.0
         worker_recovery_check_interval_seconds: float = 10.0
 

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -16,15 +16,15 @@ executor:
 #    instance:
 #      cores: 2
 #      processes: 1
-#      memory: "40GB"
+#      memory: "20GB"
 #      queue: "cpu_small"
 #      account: "hpc-public"
 #      job_extra_directives:
 #        - "--propagate"
 #        - "--time=12:00:00"
 #    scale:
-#      minimum_jobs: 11
-#      maximum_jobs: 11
+#      minimum_jobs: 10
+#      maximum_jobs: 22
 #      worker_recovery_timeout_seconds: 600
 #      worker_recovery_check_interval_seconds: 10
 


### PR DESCRIPTION
- reduce worker memory allocation from 40 GB to 20 GB
- start with a minimum of 10 workers
- allow adaptive scaling up to 22 workers
- keep the driver allocation at 40 GB
- update the SLURM configuration template