### PR TITLE
Refactor homogenized filtering and config policy

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 MAINDIR = Path(__file__).parent
 DATASETS_DIR = os.getenv("DATASETS_DIR", "/datasets")
@@ -99,16 +99,24 @@ class Inputs(BaseModel):
 
 
 class Param(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     class Run(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
         combine_type: str = "concatenate"
         tie_treatment_option: str = "remove_all"
         flags_translation_file: str = str(Path(MAINDIR, "flags_translation.yaml"))
 
     class Preparation(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
         repartition_prepared_catalogs: bool = False
         prepared_partition_size: str = "256MB"
 
     class Diagnostics(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
         tie_invariant_diagnostics_enabled: bool = True
         tie_invariant_diagnostics_detailed_enabled: bool = False
         tie_invariant_diagnostics_sample_size: int = 10
@@ -130,7 +138,11 @@ class Param(BaseModel):
             return self
 
     class Filters(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
         class InstrumentTypeHomogenized(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+
             include_spectroscopic: bool = True
             include_grism: bool = True
             include_photometric: bool = True
@@ -146,6 +158,8 @@ class Param(BaseModel):
                 return self
 
         class ObjectTypeHomogenized(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+
             include_unclassified: bool = True
             include_galaxy: bool = True
             include_star: bool = False
@@ -170,7 +184,11 @@ class Param(BaseModel):
         object_type_homogenized: ObjectTypeHomogenized = ObjectTypeHomogenized()
 
     class Output(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
         class HomogenizedColumns(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+
             z_flag_homogenized: str = "always"
             instrument_type_homogenized: str = "always"
             object_type_homogenized: str = "always"
@@ -196,77 +214,6 @@ class Param(BaseModel):
     preparation: Preparation = Preparation()
     diagnostics: Diagnostics = Diagnostics()
     output: Output = Output()
-
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_legacy_layout(cls, data: Any) -> Any:
-        if not isinstance(data, dict):
-            return data
-        migrated = dict(data)
-
-        run = dict(migrated.get("run") or {})
-        for key in ("combine_type", "tie_treatment_option", "flags_translation_file"):
-            if key in migrated and key not in run:
-                run[key] = migrated[key]
-        if run:
-            migrated["run"] = run
-
-        filters = dict(migrated.get("filters") or {})
-        if "z_flag_homogenized_value_to_cut" in migrated:
-            filters.setdefault(
-                "z_flag_homogenized_value_to_cut",
-                migrated["z_flag_homogenized_value_to_cut"],
-            )
-
-        instrument = dict(filters.get("instrument_type_homogenized") or {})
-        instrument_aliases = {
-            "include_spectroscopic_ith": "include_spectroscopic",
-            "include_grism_ith": "include_grism",
-            "include_photometric_ith": "include_photometric",
-            "include_unclassified_ith": "include_unclassified",
-        }
-        for old, new in instrument_aliases.items():
-            if old in migrated and new not in instrument:
-                instrument[new] = migrated[old]
-        if instrument:
-            filters["instrument_type_homogenized"] = instrument
-
-        object_type = dict(filters.get("object_type_homogenized") or {})
-        object_aliases = {
-            "include_unclassified_oth": "include_unclassified",
-            "include_galaxy_oth": "include_galaxy",
-            "include_star_oth": "include_star",
-            "include_agn_oth": "include_agn",
-            "include_qso_oth": "include_qso",
-            "include_galactic_oth": "include_galactic",
-        }
-        for old, new in object_aliases.items():
-            if old in migrated and new not in object_type:
-                object_type[new] = migrated[old]
-        if object_type:
-            filters["object_type_homogenized"] = object_type
-        if filters:
-            migrated["filters"] = filters
-
-        output = dict(migrated.get("output") or {})
-        if "extra_columns" in migrated:
-            output.setdefault("extra_columns", migrated["extra_columns"])
-        if "output_homogenized_columns" in migrated:
-            output.setdefault(
-                "homogenized_columns", migrated["output_homogenized_columns"]
-            )
-        for key in ("insert_DP1_footprint_flag", "insert_rubin_footprint_flag"):
-            if key in migrated and key not in output:
-                output[key] = migrated[key]
-        if output:
-            migrated["output"] = output
-
-        diagnostics = dict(migrated.get("diagnostics") or {})
-        diagnostics.pop("expr_column_schema", None)
-        if diagnostics:
-            migrated["diagnostics"] = diagnostics
-
-        return migrated
 
 
 class Config(BaseModel):

--- a/config.py
+++ b/config.py
@@ -99,33 +99,174 @@ class Inputs(BaseModel):
 
 
 class Param(BaseModel):
-    combine_type: str = "concatenate"
-    extra_columns: dict[str, Any] = Field(default_factory=dict)
-    # Zero disables the cut; valid active cuts are 1, 2, 3, 4.
-    z_flag_homogenized_value_to_cut: float = 3.0
-    include_unclassified: bool = True
-    include_galaxy: bool = True
-    include_star: bool = False
-    include_agn: bool = True
-    include_qso: bool = True
-    include_galactic: bool = False
-    flags_translation_file: str = str(Path(MAINDIR, "flags_translation.yaml"))
-    insert_DP1_footprint_flag: bool = False
-    insert_rubin_footprint_flag: bool = False
+    class Run(BaseModel):
+        combine_type: str = "concatenate"
+        tie_treatment_option: str = "remove_all"
+        flags_translation_file: str = str(Path(MAINDIR, "flags_translation.yaml"))
 
-    @model_validator(mode="after")
-    def validate_object_type_inclusion(self):
-        inclusion = (
-            self.include_unclassified,
-            self.include_galaxy,
-            self.include_star,
-            self.include_agn,
-            self.include_qso,
-            self.include_galactic,
+    class Preparation(BaseModel):
+        repartition_prepared_catalogs: bool = False
+        prepared_partition_size: str = "256MB"
+
+    class Diagnostics(BaseModel):
+        tie_invariant_diagnostics_enabled: bool = True
+        tie_invariant_diagnostics_detailed_enabled: bool = False
+        tie_invariant_diagnostics_sample_size: int = 10
+        tie_invariant_diagnostics_max_rows: int = 100
+        label_merge_diagnostics_enabled: bool = True
+        crossmatch_geometry_diagnostics_enabled: bool = False
+        representative_radius_diagnostics_enabled: bool = False
+        dedup_edge_diagnostics_enabled: bool = False
+        save_expr_columns: bool = False
+
+        @model_validator(mode="after")
+        def validate_limits(self):
+            if self.tie_invariant_diagnostics_sample_size < 1:
+                raise ValueError(
+                    "tie_invariant_diagnostics_sample_size must be positive"
+                )
+            if self.tie_invariant_diagnostics_max_rows < 1:
+                raise ValueError("tie_invariant_diagnostics_max_rows must be positive")
+            return self
+
+    class Filters(BaseModel):
+        class InstrumentTypeHomogenized(BaseModel):
+            include_spectroscopic: bool = True
+            include_grism: bool = True
+            include_photometric: bool = True
+            include_unclassified: bool = True
+
+            @model_validator(mode="after")
+            def validate_any_enabled(self):
+                if not any(self.model_dump().values()):
+                    raise ValueError(
+                        "at least one instrument_type_homogenized include option "
+                        "must be true"
+                    )
+                return self
+
+        class ObjectTypeHomogenized(BaseModel):
+            include_unclassified: bool = True
+            include_galaxy: bool = True
+            include_star: bool = False
+            include_agn: bool = True
+            include_qso: bool = True
+            include_galactic: bool = False
+
+            @model_validator(mode="after")
+            def validate_any_enabled(self):
+                if not any(self.model_dump().values()):
+                    raise ValueError(
+                        "at least one object_type_homogenized include option "
+                        "must be true"
+                    )
+                return self
+
+        # Zero disables the cut; valid active cuts are 1, 2, 3, 4.
+        z_flag_homogenized_value_to_cut: float = 3.0
+        instrument_type_homogenized: InstrumentTypeHomogenized = (
+            InstrumentTypeHomogenized()
         )
-        if not any(inclusion):
-            raise ValueError("at least one include_* object-type option must be true")
-        return self
+        object_type_homogenized: ObjectTypeHomogenized = ObjectTypeHomogenized()
+
+    class Output(BaseModel):
+        class HomogenizedColumns(BaseModel):
+            z_flag_homogenized: str = "always"
+            instrument_type_homogenized: str = "always"
+            object_type_homogenized: str = "always"
+
+            @model_validator(mode="after")
+            def validate_modes(self):
+                valid = {"auto", "always", "never"}
+                for field, value in self.model_dump().items():
+                    if value not in valid:
+                        raise ValueError(
+                            f"output.homogenized_columns.{field} must be one of "
+                            f"{sorted(valid)}"
+                        )
+                return self
+
+        extra_columns: dict[str, Any] = Field(default_factory=dict)
+        homogenized_columns: HomogenizedColumns = HomogenizedColumns()
+        insert_DP1_footprint_flag: bool = False
+        insert_rubin_footprint_flag: bool = False
+
+    run: Run = Run()
+    filters: Filters = Filters()
+    preparation: Preparation = Preparation()
+    diagnostics: Diagnostics = Diagnostics()
+    output: Output = Output()
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_legacy_layout(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        migrated = dict(data)
+
+        run = dict(migrated.get("run") or {})
+        for key in ("combine_type", "tie_treatment_option", "flags_translation_file"):
+            if key in migrated and key not in run:
+                run[key] = migrated[key]
+        if run:
+            migrated["run"] = run
+
+        filters = dict(migrated.get("filters") or {})
+        if "z_flag_homogenized_value_to_cut" in migrated:
+            filters.setdefault(
+                "z_flag_homogenized_value_to_cut",
+                migrated["z_flag_homogenized_value_to_cut"],
+            )
+
+        instrument = dict(filters.get("instrument_type_homogenized") or {})
+        instrument_aliases = {
+            "include_spectroscopic_ith": "include_spectroscopic",
+            "include_grism_ith": "include_grism",
+            "include_photometric_ith": "include_photometric",
+            "include_unclassified_ith": "include_unclassified",
+        }
+        for old, new in instrument_aliases.items():
+            if old in migrated and new not in instrument:
+                instrument[new] = migrated[old]
+        if instrument:
+            filters["instrument_type_homogenized"] = instrument
+
+        object_type = dict(filters.get("object_type_homogenized") or {})
+        object_aliases = {
+            "include_unclassified_oth": "include_unclassified",
+            "include_galaxy_oth": "include_galaxy",
+            "include_star_oth": "include_star",
+            "include_agn_oth": "include_agn",
+            "include_qso_oth": "include_qso",
+            "include_galactic_oth": "include_galactic",
+        }
+        for old, new in object_aliases.items():
+            if old in migrated and new not in object_type:
+                object_type[new] = migrated[old]
+        if object_type:
+            filters["object_type_homogenized"] = object_type
+        if filters:
+            migrated["filters"] = filters
+
+        output = dict(migrated.get("output") or {})
+        if "extra_columns" in migrated:
+            output.setdefault("extra_columns", migrated["extra_columns"])
+        if "output_homogenized_columns" in migrated:
+            output.setdefault(
+                "homogenized_columns", migrated["output_homogenized_columns"]
+            )
+        for key in ("insert_DP1_footprint_flag", "insert_rubin_footprint_flag"):
+            if key in migrated and key not in output:
+                output[key] = migrated[key]
+        if output:
+            migrated["output"] = output
+
+        diagnostics = dict(migrated.get("diagnostics") or {})
+        diagnostics.pop("expr_column_schema", None)
+        if diagnostics:
+            migrated["diagnostics"] = diagnostics
+
+        return migrated
 
 
 class Config(BaseModel):
@@ -142,8 +283,8 @@ if __name__ == "__main__":
     import yaml
 
     cfg = Config()
+    data = cfg.model_dump()
 
     with open("config.yml", "w") as outfile:
-        data_json = cfg.model_dump()
-        print(data_json)
-        yaml.dump(data_json, outfile)
+        print(cfg.model_dump_json(indent=2))
+        yaml.dump(data, outfile, sort_keys=False, allow_unicode=True)

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -119,7 +119,7 @@ param:
       object_type_homogenized: always
     insert_DP1_footprint_flag: false # Adds is_in_DP1_fields as 1/0.
     insert_rubin_footprint_flag: false # Adds is_in_rubin_footprint as 1/0.
-    publish_integrity_check: basic # basic: exists/size/mtime; checksum: also compare sha256.
+    publish_integrity_check: basic # basic: exists/size; checksum: also compare sha256.
 
   diagnostics:
     tie_invariant_diagnostics_enabled: true # Aggregate reason counts for invalid tie groups.

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -119,6 +119,7 @@ param:
       object_type_homogenized: always
     insert_DP1_footprint_flag: false # Adds is_in_DP1_fields as 1/0.
     insert_rubin_footprint_flag: false # Adds is_in_rubin_footprint as 1/0.
+    publish_integrity_check: basic # basic: exists/size/mtime; checksum: also compare sha256.
 
   diagnostics:
     tie_invariant_diagnostics_enabled: true # Aggregate reason counts for invalid tie groups.

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -76,26 +76,57 @@ output_name: "crd" # Name prefix for the final output files
 output_format: "parquet" # Output format: csv, parquet, hdf5, fits, or hats
 
 param:
-  combine_type: "concatenate_and_mark_duplicates" # Options: "concatenate", "concatenate_and_mark_duplicates", or "concatenate_and_remove_duplicates"
-  tie_treatment_option: "remove_all" # Options (only for concatenate_and_remove_duplicates): "remove_all", "keep_all", "draw_one"
-  # Extra output columns. Existing values are preserved and converted to the
-  # declared type; catalogs without a column receive typed null values.
-  # Supported types: str, float, int, bool.
-  extra_columns: {}
-  # extra_columns:
-  #   DELTACHI2: float
-  #   ORIGINAL_ID:
-  #     source: id
-  #     type: str
-  z_flag_homogenized_value_to_cut: 0.0 # 0 disables the cut; valid active cuts are 1, 2, 3, 4.
-  # Object types allowed to participate in the deduplication graph. Disabled
-  # types remain in marked outputs as isolated rows with tie_result=3.
-  include_unclassified: true
-  include_galaxy: true
-  include_star: false
-  include_agn: true
-  include_qso: true
-  include_galactic: false
-  insert_DP1_footprint_flag: false # Adds is_in_DP1_fields (1/0)
-  insert_rubin_footprint_flag: false # Adds is_in_rubin_footprint (1/0)
-  flags_translation_file: flags_translation.yaml # File with homogenization rules for z_flag and type
+  # The template uses the recommended production policy. Internal fallbacks are
+  # non-restrictive: no z-flag cut, all classes included, homogenized columns kept.
+  run:
+    combine_type: "concatenate_and_mark_duplicates" # concatenate, concatenate_and_mark_duplicates, concatenate_and_remove_duplicates
+    tie_treatment_option: "remove_all" # remove_all, keep_all, draw_one; used only by concatenate_and_remove_duplicates
+    flags_translation_file: flags_translation.yaml # Homogenization and deduplication science rules.
+
+  preparation:
+    repartition_prepared_catalogs: false # Optional full-data pass to resize prepared partitions.
+    prepared_partition_size: "256MB" # Target size when repartition_prepared_catalogs is true.
+
+  filters:
+    z_flag_homogenized_value_to_cut: 3.0 # 0 disables the cut; active cuts are 1, 2, 3, or 4.
+    instrument_type_homogenized:
+      include_spectroscopic: true # instrument_type_homogenized == "s"
+      include_grism: true # instrument_type_homogenized == "g"
+      include_photometric: true # instrument_type_homogenized == "p"
+      include_unclassified: true # missing instrument_type_homogenized
+    object_type_homogenized:
+      include_unclassified: true # missing object_type_homogenized
+      include_galaxy: true
+      include_star: false
+      include_agn: true
+      include_qso: true
+      include_galactic: false
+
+  output:
+    # Extra output columns. Values are cast to the declared type; missing source
+    # columns are emitted as typed nulls. Supported types: str, float, int, bool.
+    extra_columns: {}
+    # extra_columns:
+    #   DELTACHI2: float
+    #   ORIGINAL_ID:
+    #     source: id
+    #     type: str
+    # Controls final output only. Internally all homogenized columns are created.
+    # Options: always, auto, never. Auto keeps columns used by filters or dedup.
+    homogenized_columns:
+      z_flag_homogenized: always
+      instrument_type_homogenized: always
+      object_type_homogenized: always
+    insert_DP1_footprint_flag: false # Adds is_in_DP1_fields as 1/0.
+    insert_rubin_footprint_flag: false # Adds is_in_rubin_footprint as 1/0.
+
+  diagnostics:
+    tie_invariant_diagnostics_enabled: true # Aggregate reason counts for invalid tie groups.
+    tie_invariant_diagnostics_detailed_enabled: false # Sample invalid groups and member CRD_IDs.
+    tie_invariant_diagnostics_sample_size: 10 # Maximum invalid groups in the detailed sample.
+    tie_invariant_diagnostics_max_rows: 100 # Maximum member rows collected across sampled groups.
+    label_merge_diagnostics_enabled: true # Count rows without a newly computed dedup label.
+    crossmatch_geometry_diagnostics_enabled: false # Separation and component-shape diagnostics.
+    representative_radius_diagnostics_enabled: false # Component radius diagnostics during deduplication.
+    dedup_edge_diagnostics_enabled: false # Extra graph diagnostics during edge construction.
+    save_expr_columns: false # Preserve columns referenced by flags_translation expressions.

--- a/flags_translation.yaml
+++ b/flags_translation.yaml
@@ -24,27 +24,66 @@ margin_threshold_arcsec: 5.0   # HATS margin used by independent partition-local
 margin_warning_fraction: 0.8   # Warn when a boundary component spans this fraction of the margin.
 validate_global_graph_edges: false  # Distributed edge/group consistency check (costs two joins).
 validate_global_tie_invariants: true  # Fail on invalid winner/hard-tie patterns after label merge.
-tie_invariant_diagnostics_enabled: true  # Cheap aggregate reason counts for invalid tie groups.
-tie_invariant_diagnostics_detailed_enabled: false  # Expensive sample of group IDs and member CRD_IDs.
-tie_invariant_diagnostics_sample_size: 10  # Maximum invalid groups in the detailed sample.
-tie_invariant_diagnostics_max_rows: 100  # Maximum member rows collected across sampled groups.
-label_merge_diagnostics_enabled: true  # Cheap count of rows without a newly computed dedup label.
 validate_crd_id_uniqueness: true  # Global nunique validation for every prepared input catalog.
-repartition_prepared_catalogs: false  # Extra full-data pass to resize prepared partitions.
-prepared_partition_size: "256MB"  # Used only when repartition_prepared_catalogs is enabled.
 
 crossmatch_n_neighbors: 160     # Number of nearest neighbors to consider during crossmatching.
 crossmatch_saturation_enabled: true  # Compute per-source saturation metrics and thresholds.
 crossmatch_saturation_warn_fraction: 0.01  # Warn when >=1% of all source objects reach n_neighbors.
 crossmatch_saturation_fail_fraction: 0.10  # Fail at >=10%; set null to disable failure.
-crossmatch_geometry_diagnostics_enabled: false  # Separation/component-shape diagnostics over materialized matches.
-representative_radius_diagnostics_enabled: false  # Component radius/extent diagnostics during and after deduplication.
-dedup_edge_diagnostics_enabled: false  # Additional diagnostics for object types excluded while building the deduplication graph.
 
 instrument_type_priority:
   s: 3     # Spectroscopic (most reliable type)
   g: 2     # Grism
   p: 1     # Photometric (least reliable)
+
+# Column type hints for variables referenced by translation expressions.
+# Protected pipeline columns (id, ra, dec, z, z_flag, z_err, survey,
+# instrument_type, object_type) are typed internally and omitted here.
+expr_column_schema:
+  CLASS: str
+  COMM: str
+  Class: float
+  J1: float
+  J2: float
+  Remarks: str
+  SPECPRIMARY: float
+  SPECTYPE: str
+  TYPE: str
+  ZCAT_PRIMARY: bool
+  agn_flag: float
+  chi_a: float
+  classFlag: float
+  flag1: float
+  flag2: float
+  l68: float
+  l95: float
+  lp_NbFilt: float
+  lp_type: float
+  lp_zMinChi2: float
+  lp_zPDF: float
+  lp_zPDF_l68: float
+  lp_zPDF_u68: float
+  mst: float
+  nbfilt: float
+  nfilt: float
+  spe_class: str
+  tSp: float
+  type: str
+  u68: float
+  u95: float
+  use_phot: float
+  use_zgrism: float
+  z500: float
+  z_best_s: float
+  z_ml: float
+  z_peak: float
+  z_spec: float
+  zbest_type: str
+  zchi2: float
+  zfinal_type: str
+  zpdf_med: float
+  zspec: float
+  zspec_survey: str
 
 # === Survey-specific translation rules for z_flag, instrument, and object type ===
 # These are our internal definitions used to harmonize redshift quality and instrument types across surveys.
@@ -77,20 +116,6 @@ instrument_type_priority:
 # z_flag and instrument translations accept `fast_path: auto|disabled|required`.
 # `auto` is the default, `disabled` forces YAML rules, and `required` fails when
 # the input is not compatible with the corresponding probability/s-g-p fast path.
-
-save_expr_columns: false
-
-expr_column_schema:
-  z_best_s: float
-  z_spec: float
-  use_zgrism: float
-  flag1: float
-  flag2: float
-  use_phot: float
-  zspec_survey: str
-  zspec: float
-  z_flag: float
-  ZCAT_PRIMARY: bool
 
 translation_rules:
 

--- a/packages/deduplication.py
+++ b/packages/deduplication.py
@@ -81,22 +81,35 @@ __all__ = [
     "filter_dask_by_tie_treatment",
     "filter_pandas_by_tie_treatment",
     "validate_object_type_inclusion",
+    "validate_instrument_type_inclusion",
 ]
 
 OBJECT_TYPE_INCLUDE_DEFAULTS = {
-    "include_unclassified": True,
-    "include_galaxy": True,
-    "include_star": False,
-    "include_agn": True,
-    "include_qso": True,
-    "include_galactic": False,
+    "include_unclassified_oth": True,
+    "include_galaxy_oth": True,
+    "include_star_oth": True,
+    "include_agn_oth": True,
+    "include_qso_oth": True,
+    "include_galactic_oth": True,
 }
 _OBJECT_TYPE_TO_INCLUDE_KEY = {
-    "galaxy": "include_galaxy",
-    "star": "include_star",
-    "agn": "include_agn",
-    "qso": "include_qso",
-    "galactic": "include_galactic",
+    "galaxy": "include_galaxy_oth",
+    "star": "include_star_oth",
+    "agn": "include_agn_oth",
+    "qso": "include_qso_oth",
+    "galactic": "include_galactic_oth",
+}
+
+INSTRUMENT_TYPE_INCLUDE_DEFAULTS = {
+    "include_spectroscopic_ith": True,
+    "include_grism_ith": True,
+    "include_photometric_ith": True,
+    "include_unclassified_ith": True,
+}
+_INSTRUMENT_TYPE_TO_INCLUDE_KEY = {
+    "s": "include_spectroscopic_ith",
+    "g": "include_grism_ith",
+    "p": "include_photometric_ith",
 }
 
 
@@ -119,13 +132,34 @@ def validate_object_type_inclusion(config: Mapping[str, object] | None) -> dict[
     return result
 
 
+def validate_instrument_type_inclusion(
+    config: Mapping[str, object] | None,
+) -> dict[str, bool]:
+    """Return strict, complete instrument-type inclusion settings."""
+    supplied = dict(config or {})
+    unknown = sorted(set(supplied) - set(INSTRUMENT_TYPE_INCLUDE_DEFAULTS))
+    if unknown:
+        raise ValueError(f"Unknown instrument-type inclusion option(s): {unknown}")
+    result = dict(INSTRUMENT_TYPE_INCLUDE_DEFAULTS)
+    for key, value in supplied.items():
+        if not isinstance(value, bool):
+            raise TypeError(f"param.{key} must be a boolean, got {type(value).__name__}")
+        result[key] = value
+    if not any(result.values()):
+        raise ValueError(
+            "At least one instrument-type inclusion option must be true: "
+            + ", ".join(INSTRUMENT_TYPE_INCLUDE_DEFAULTS)
+        )
+    return result
+
+
 def _excluded_object_type_mask(
     object_types: pd.Series,
     inclusion: Mapping[str, bool],
 ) -> pd.Series:
     normalized = object_types.astype("string").str.strip().str.lower()
     included = pd.Series(False, index=object_types.index, dtype=bool)
-    included |= normalized.isna() & bool(inclusion["include_unclassified"])
+    included |= normalized.isna() & bool(inclusion["include_unclassified_oth"])
     for object_type, key in _OBJECT_TYPE_TO_INCLUDE_KEY.items():
         included |= normalized.eq(object_type).fillna(False) & bool(inclusion[key])
     return ~included
@@ -325,9 +359,8 @@ def _validate_local_tie_invariants(
 ) -> None:
     """Validate winner/hard-tie semantics for every local component."""
     tie = pd.to_numeric(df[tie_col], errors="coerce")
-    participants = ~tie.eq(3.0)
-    participating = df.loc[participants, [group_col]].copy()
-    participating["__tie"] = tie.loc[participants].to_numpy()
+    participating = df.loc[:, [group_col]].copy()
+    participating["__tie"] = tie.to_numpy()
     for gid_value, component in participating.groupby(group_col, dropna=False):
         values = component["__tie"]
         n_one = int(values.eq(1).sum())
@@ -590,12 +623,7 @@ def _edge_rows_partition(
     tie_col: str,
 ) -> pd.DataFrame:
     """Extract directed graph edges from participating rows."""
-    tie = (
-        pd.to_numeric(part[tie_col], errors="coerce")
-        if tie_col in part.columns
-        else pd.Series(0, index=part.index, dtype="int8")
-    )
-    work = part.loc[~tie.eq(3.0), [crd_col, compared_col]].copy()
+    work = part.loc[:, [crd_col, compared_col]].copy()
     if work.empty:
         return pd.DataFrame(
             {
@@ -639,17 +667,9 @@ def count_global_edge_group_mismatches(
         meta=meta,
     ).drop_duplicates()
 
-    tie = (
-        dd.to_numeric(df[tie_col], errors="coerce")
-        if tie_col in df.columns
-        else df[crd_col].map_partitions(
-            lambda s: pd.Series(0, index=s.index, dtype="int8"),
-            meta=pd.Series(dtype="int8"),
-        )
-    )
     groups = (
         df[[crd_col, group_col]]
-        .assign(is_excluded=tie.eq(3.0))
+        .assign(is_excluded=False)
         .rename(columns={crd_col: "node", group_col: "node_group"})
     )
     groups = groups.assign(node=groups["node"].astype("string[pyarrow]"))
@@ -709,10 +729,8 @@ def build_global_tie_invariant_diagnostics(
 ) -> tuple[dd.DataFrame, object]:
     """Build lazy per-group invariant diagnostics and missing-group count."""
     tie = dd.to_numeric(df[tie_col], errors="coerce")
-    # tie_result=3 is the public, type-agnostic marker for rows excluded from
-    # the graph. z_flag_col is retained only for API compatibility.
-    participating_mask = ~tie.eq(3)
-    participants = df.loc[participating_mask, [group_col]].assign(
+    # z_flag_col is retained only for API compatibility.
+    participants = df.loc[:, [group_col]].assign(
         n=1,
         n0=tie.eq(0).astype("int8"),
         n1=tie.eq(1).astype("int8"),
@@ -1137,9 +1155,7 @@ def _apply_guard_restore_local(
         df[compared_col], excluded_ids
     )
 
-    # Rule:
-    # Excluded rows remain tie_result=3. Participating rows with no usable
-    # neighbors recover their original label.
+    # Rule: participating rows with no usable neighbors recover their original label.
     restore_mask = (~excluded) & (cmp_empty | only_excluded_neighbors)
 
     # Apply restoration.
@@ -1170,7 +1186,6 @@ def _resolve_group(
         if excluded_mask is None
         else excluded_mask.reindex(g.index).fillna(False).astype(bool)
     )
-    out.loc[excluded.index[excluded], "tie_result_new"] = 3
 
     cand = g[~excluded].copy()
     if cand.empty:
@@ -1268,19 +1283,9 @@ def deduplicate_pandas(
         raise KeyError(f"Missing required columns: {missing}")
 
     out = df.copy()
-    inclusion = validate_object_type_inclusion(object_type_inclusion)
-    excluded_object_types = sorted(
-        object_type
-        for object_type, option in _OBJECT_TYPE_TO_INCLUDE_KEY.items()
-        if not inclusion[option]
-    )
-    if not inclusion["include_unclassified"]:
-        excluded_object_types.append("unclassified")
-    object_types = out.get(
-        "object_type_homogenized",
-        pd.Series(pd.NA, index=out.index, dtype="string"),
-    )
-    excluded_mask = _excluded_object_type_mask(object_types, inclusion)
+    validate_object_type_inclusion(object_type_inclusion)
+    excluded_object_types: list[str] = []
+    excluded_mask = pd.Series(False, index=out.index, dtype=bool)
 
     tie_col_orig = f"{tie_col}_orig"
     if tie_col in out.columns:
@@ -1308,7 +1313,7 @@ def deduplicate_pandas(
         excluded_neighbor_edges = diag.get("n_edges_starB_excluded")
         if isinstance(excluded_neighbor_edges, int) and excluded_neighbor_edges > 0:
             lg.warning(
-                "%s Object types excluded from deduplication graph: "
+                "%s Edge build saw pre-filtered object types: "
                 "types=%s, rows_excluded=%d, edges_raw=%d, "
                 "excluded_neighbor_edges=%d, edges_kept=%d",
                 tag,
@@ -1320,7 +1325,7 @@ def deduplicate_pandas(
             )
         elif partition_tag is None:
             lg.info(
-                "%s Edge build summary: excluded_object_types=%s, "
+                "%s Edge build summary: pre_filtered_object_types=%s, "
                 "rows_excluded=%d, edges_raw=%d, "
                 "excluded_neighbor_edges=%s, edges_kept=%d",
                 tag,
@@ -1377,7 +1382,7 @@ def deduplicate_pandas(
                 )
                 na_mask[bridged.index.to_numpy()] = False
 
-    # Fallback for rows still without group id (avoid mixing stars in graph).
+    # Fallback for rows still without group id.
     if na_mask.any():
         pos_na = np.flatnonzero(na_mask)
 
@@ -1453,15 +1458,12 @@ def deduplicate_pandas(
     is_singleton = group_sizes.eq(1)
 
     is_singleton_np = is_singleton.to_numpy(dtype=bool, na_value=False)
-    is_excluded_np = excluded_mask.to_numpy(dtype=bool, na_value=False)
 
     tr = np.zeros(len(out), dtype=np.int8)
-    tr[is_excluded_np] = 3
-    tr[is_singleton_np & ~is_excluded_np] = 1
+    tr[is_singleton_np] = 1
 
     is_multi = ~is_singleton
-    participating = ~excluded_mask
-    survivors = (is_multi & participating).copy()
+    survivors = is_multi.copy()
 
     zf_num = _effective_z_flag_score(out)
 
@@ -1506,18 +1508,6 @@ def deduplicate_pandas(
     tr[multi_winner.to_numpy(dtype=bool, na_value=False)] = 2
 
     out[tie_col] = pd.Series(tr, index=out.index).astype("Int8")
-
-    tr_num = pd.to_numeric(out[tie_col], errors="coerce")
-    eq3_np = tr_num.eq(3.0).to_numpy(dtype=bool, na_value=False)
-    excluded_np = excluded_mask.to_numpy(dtype=bool, na_value=False)
-    is_single_np = is_singleton.to_numpy(dtype=bool, na_value=False)
-
-    invalid_3_np = eq3_np & ~excluded_np
-    if invalid_3_np.any():
-        invalid_3 = pd.Series(invalid_3_np, index=out.index)
-        single = pd.Series(is_single_np, index=out.index)
-        out.loc[invalid_3 & single, tie_col] = np.int8(1)
-        out.loc[invalid_3 & ~single, tie_col] = np.int8(0)
 
     z_num = _to_numeric(out[z_col]).astype("float64")
     f_num = zf_num.fillna(-np.inf)
@@ -1646,15 +1636,6 @@ def deduplicate_pandas(
                 out.iloc[[p1, p2], out.columns.get_loc(tie_col)] = np.array(
                     [2, 2], dtype=np.int8
                 )
-
-    out = _apply_guard_restore_local(
-        out,
-        crd_col=crd_col,
-        compared_col=compared_col,
-        excluded_mask=excluded_mask,
-        tie_col=tie_col,
-        tie_col_orig=tie_col_orig,
-    )
 
     drop_cols = []
     if tie_col_orig in out.columns:
@@ -1882,9 +1863,7 @@ def _dedup_local_with_margin(
         if max_representative_radius_arcsec is None:
             # Without radius truncation, every participating edge must remain
             # inside one canonical component.
-            semantic_exclusion = pd.to_numeric(
-                solved[tie_col], errors="coerce"
-            ).eq(3.0)
+            semantic_exclusion = pd.Series(False, index=solved.index, dtype=bool)
             edge_nodes, edge_uv, _ = _build_edges_fast(
                 solved,
                 crd_col=crd_col,

--- a/packages/specz.py
+++ b/packages/specz.py
@@ -15,6 +15,7 @@ Public API:
 # -----------------------
 import ast as _ast
 import difflib
+import hashlib
 import json
 import logging
 import os
@@ -1972,25 +1973,52 @@ def _as_bool_config(value: Any, default: bool) -> bool:
 # -----------------------
 # CRD_ID generation
 # -----------------------
+def _format_crd_signature_value(value: object) -> str:
+    """Return a stable scalar representation for CRD_ID hashing."""
+    if pd.isna(value):
+        return "NA"
+    number = float(value)
+    if number == 0.0:
+        number = 0.0
+    return format(number, ".17g")
+
+
+def _crd_signature(row: tuple[object, object, object]) -> str:
+    """Return the canonical row signature used for CRD_ID generation."""
+    ra, dec, z = row
+    return (
+        f"ra={_format_crd_signature_value(ra)}|"
+        f"dec={_format_crd_signature_value(dec)}|"
+        f"z={_format_crd_signature_value(z)}"
+    )
+
+
+def _crd_hash_id(catalog_prefix: str, row: tuple[object, object, object]) -> str:
+    """Return a short deterministic CRD_ID for one canonical row signature."""
+    digest = hashlib.blake2b(_crd_signature(row).encode("utf-8"), digest_size=8)
+    return f"CRD{catalog_prefix}_{digest.hexdigest()}"
+
+
 def _generate_crd_ids(
     df: dd.DataFrame,
     product_name: str,
     temp_dir: str,
     client: "Client | None" = None,
 ) -> dd.DataFrame:
-    """Assign stable, catalog-scoped CRD_IDs.
+    """Assign deterministic, catalog-scoped CRD_IDs from RA/DEC/Z values.
 
     Args:
         df: Input frame after schema normalization.
         product_name: Internal name (expects numeric prefix before underscore).
         temp_dir: Unused, kept for signature stability.
-        client: Optional distributed client used to stabilize the input graph.
+        client: Unused, kept for signature stability.
 
     Returns:
         dd.DataFrame: Frame with CRD_ID column (Arrow string dtype).
 
     Raises:
         ValueError: If numeric prefix cannot be extracted from product_name.
+        KeyError: If any of the required identity columns are missing.
     """
     m = re.match(r"(\d+)_", product_name)
     if not m:
@@ -1999,34 +2027,21 @@ def _generate_crd_ids(
         )
     catalog_prefix = m.group(1)
 
-    # Stabilize partition contents before measuring offsets. Otherwise a second
-    # execution of a non-deterministic upstream graph can reuse an ID range for
-    # different rows.
-    df = df.persist()
-    if client is not None:
-        wait(df)
+    required = ["ra", "dec", "z"]
+    missing = [column for column in required if column not in df.columns]
+    if missing:
+        raise KeyError(f"Missing required columns for CRD_ID generation: {missing}")
 
-    sizes = [int(size) for size in df.map_partitions(len).compute().tolist()]
-    offsets = [0]
-    for s in sizes[:-1]:
-        offsets.append(offsets[-1] + s)
-
-    def _add_crd(part: pd.DataFrame, start: int) -> pd.DataFrame:
+    def _add_crd(part: pd.DataFrame) -> pd.DataFrame:
         p = part.copy()
-        n = len(p)
-        p["CRD_ID"] = [f"CRD{catalog_prefix}_{start + i + 1}" for i in range(n)]
+        values = p[required].itertuples(index=False, name=None)
+        p["CRD_ID"] = [_crd_hash_id(catalog_prefix, row) for row in values]
         return p
 
-    parts = [
-        df.get_partition(i).map_partitions(
-            _add_crd,
-            offset,
-            meta=df._meta.assign(CRD_ID=pd.Series(pd.array([], dtype=DTYPE_STR))),
-        )
-        for i, offset in enumerate(offsets)
-    ]
-    df = dd.concat(parts)
-    return df
+    return df.map_partitions(
+        _add_crd,
+        meta=df._meta.assign(CRD_ID=pd.Series(pd.array([], dtype=DTYPE_STR))),
+    )
 
 
 def _validate_unique_crd_ids(

--- a/packages/specz.py
+++ b/packages/specz.py
@@ -2875,6 +2875,7 @@ def prepare_catalog(
         require_instrument_type_homogenized=_active_instrument_type_filter(
             param_config
         ),
+        require_object_type_homogenized=_active_object_type_filter(param_config),
     )
     df = _normalize_custom_tiebreaking_priorities(
         df,

--- a/packages/specz.py
+++ b/packages/specz.py
@@ -2021,11 +2021,62 @@ def _crd_hash_id(
     return f"CRD{catalog_prefix}_{digest.hexdigest()}"
 
 
+def _add_crd_signature_column(
+    df: dd.DataFrame,
+    hash_columns: Sequence[str],
+    *,
+    signature_column: str = "__crd_signature",
+) -> dd.DataFrame:
+    """Attach the canonical CRD_ID signature as a temporary column."""
+
+    def _add_signature(part: pd.DataFrame) -> pd.DataFrame:
+        p = part.copy()
+        values = p[list(hash_columns)].itertuples(index=False, name=None)
+        p[signature_column] = [_crd_signature(hash_columns, row) for row in values]
+        return p
+
+    meta = df._meta.assign(**{signature_column: pd.Series(dtype="string")})
+    return df.map_partitions(_add_signature, meta=meta)
+
+
+def _drop_duplicate_crd_signatures(
+    df: dd.DataFrame,
+    hash_columns: Sequence[str],
+    product_name: str,
+    logger: logging.LoggerAdapter | None,
+) -> dd.DataFrame:
+    """Drop rows with identical canonical CRD_ID signatures."""
+    signature_column = "__crd_signature"
+    with_signature = _add_crd_signature_column(
+        df, hash_columns, signature_column=signature_column
+    )
+    deduplicated = with_signature.drop_duplicates(subset=[signature_column])
+    before, after = dask.compute(
+        with_signature.map_partitions(len).sum(),
+        deduplicated.map_partitions(len).sum(),
+    )
+    before = int(before)
+    after = int(after)
+    dropped = before - after
+    if dropped and logger is not None:
+        logger.warning(
+            "%s dropped %d duplicate canonical input row(s) before CRD_ID "
+            "generation (rows_before=%d rows_after=%d hash_columns=%s).",
+            product_name,
+            dropped,
+            before,
+            after,
+            list(hash_columns),
+        )
+    return deduplicated.drop(columns=[signature_column])
+
+
 def _generate_crd_ids(
     df: dd.DataFrame,
     product_name: str,
     temp_dir: str,
     client: "Client | None" = None,
+    logger: logging.LoggerAdapter | None = None,
 ) -> dd.DataFrame:
     """Assign deterministic, catalog-scoped CRD_IDs from canonical input fields.
 
@@ -2034,6 +2085,7 @@ def _generate_crd_ids(
         product_name: Internal name (expects numeric prefix before underscore).
         temp_dir: Unused, kept for signature stability.
         client: Unused, kept for signature stability.
+        logger: Optional logger for duplicate-signature diagnostics.
 
     Returns:
         dd.DataFrame: Frame with CRD_ID column (Arrow string dtype).
@@ -2055,6 +2107,7 @@ def _generate_crd_ids(
     if missing:
         raise KeyError(f"Missing required columns for CRD_ID generation: {missing}")
     hash_columns = [column for column in CRD_ID_HASH_COLUMNS if column in df.columns]
+    df = _drop_duplicate_crd_signatures(df, hash_columns, product_name, logger)
 
     def _add_crd(part: pd.DataFrame) -> pd.DataFrame:
         p = part.copy()
@@ -2943,7 +2996,7 @@ def prepare_catalog(
     df, type_cast_ok = _normalize_types(df, product_name, lg)
 
     # 5) Assign CRD_IDs
-    df = _generate_crd_ids(df, product_name, temp_dir, client=client)
+    df = _generate_crd_ids(df, product_name, temp_dir, client=client, logger=lg)
     if bool(translation_config.get("validate_crd_id_uniqueness", False)):
         _validate_unique_crd_ids(df, product_name, lg)
 

--- a/packages/specz.py
+++ b/packages/specz.py
@@ -1699,18 +1699,20 @@ def _normalize_output_homogenized_columns_config(config: object) -> dict[str, st
     elif isinstance(config, dict):
         supplied = dict(config)
     else:
-        raise TypeError("param.output_homogenized_columns must be a mapping")
+        raise TypeError("param.output.homogenized_columns must be a mapping")
 
     unknown = sorted(set(supplied) - set(HOMOGENIZED_COLUMNS))
     if unknown:
-        raise ValueError(f"Unknown output_homogenized_columns option(s): {unknown}")
+        raise ValueError(
+            f"Unknown param.output.homogenized_columns option(s): {unknown}"
+        )
 
     result = {column: "always" for column in HOMOGENIZED_COLUMNS}
     for column, value in supplied.items():
         normalized = str(value).strip().lower()
         if normalized not in valid:
             raise ValueError(
-                f"param.output_homogenized_columns.{column} must be one of "
+                f"param.output.homogenized_columns.{column} must be one of "
                 f"{sorted(valid)}"
             )
         result[column] = normalized

--- a/packages/specz.py
+++ b/packages/specz.py
@@ -20,7 +20,7 @@ import json
 import logging
 import os
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Sequence
 
 # -----------------------
 # Third-party
@@ -1973,29 +1973,45 @@ def _as_bool_config(value: Any, default: bool) -> bool:
 # -----------------------
 # CRD_ID generation
 # -----------------------
+CRD_ID_REQUIRED_HASH_COLUMNS = ("ra", "dec", "z")
+CRD_ID_OPTIONAL_HASH_COLUMNS = (
+    "id",
+    "z_flag",
+    "z_err",
+    "survey",
+    "source",
+    "instrument_type",
+)
+CRD_ID_HASH_COLUMNS = CRD_ID_REQUIRED_HASH_COLUMNS + CRD_ID_OPTIONAL_HASH_COLUMNS
+
+
 def _format_crd_signature_value(value: object) -> str:
     """Return a stable scalar representation for CRD_ID hashing."""
     if pd.isna(value):
         return "NA"
-    number = float(value)
-    if number == 0.0:
-        number = 0.0
-    return format(number, ".17g")
+    if isinstance(value, (float, int, np.floating, np.integer)):
+        number = float(value)
+        if number == 0.0:
+            number = 0.0
+        return format(number, ".17g")
+    return str(value).strip()
 
 
-def _crd_signature(row: tuple[object, object, object]) -> str:
+def _crd_signature(columns: Sequence[str], row: tuple[object, ...]) -> str:
     """Return the canonical row signature used for CRD_ID generation."""
-    ra, dec, z = row
-    return (
-        f"ra={_format_crd_signature_value(ra)}|"
-        f"dec={_format_crd_signature_value(dec)}|"
-        f"z={_format_crd_signature_value(z)}"
+    return "|".join(
+        f"{column}={_format_crd_signature_value(value)}"
+        for column, value in zip(columns, row)
     )
 
 
-def _crd_hash_id(catalog_prefix: str, row: tuple[object, object, object]) -> str:
+def _crd_hash_id(
+    catalog_prefix: str, columns: Sequence[str], row: tuple[object, ...]
+) -> str:
     """Return a short deterministic CRD_ID for one canonical row signature."""
-    digest = hashlib.blake2b(_crd_signature(row).encode("utf-8"), digest_size=8)
+    digest = hashlib.blake2b(
+        _crd_signature(columns, row).encode("utf-8"), digest_size=8
+    )
     return f"CRD{catalog_prefix}_{digest.hexdigest()}"
 
 
@@ -2005,7 +2021,7 @@ def _generate_crd_ids(
     temp_dir: str,
     client: "Client | None" = None,
 ) -> dd.DataFrame:
-    """Assign deterministic, catalog-scoped CRD_IDs from RA/DEC/Z values.
+    """Assign deterministic, catalog-scoped CRD_IDs from canonical input fields.
 
     Args:
         df: Input frame after schema normalization.
@@ -2027,15 +2043,19 @@ def _generate_crd_ids(
         )
     catalog_prefix = m.group(1)
 
-    required = ["ra", "dec", "z"]
-    missing = [column for column in required if column not in df.columns]
+    missing = [
+        column for column in CRD_ID_REQUIRED_HASH_COLUMNS if column not in df.columns
+    ]
     if missing:
         raise KeyError(f"Missing required columns for CRD_ID generation: {missing}")
+    hash_columns = [column for column in CRD_ID_HASH_COLUMNS if column in df.columns]
 
     def _add_crd(part: pd.DataFrame) -> pd.DataFrame:
         p = part.copy()
-        values = p[required].itertuples(index=False, name=None)
-        p["CRD_ID"] = [_crd_hash_id(catalog_prefix, row) for row in values]
+        values = p[hash_columns].itertuples(index=False, name=None)
+        p["CRD_ID"] = [
+            _crd_hash_id(catalog_prefix, hash_columns, row) for row in values
+        ]
         return p
 
     return df.map_partitions(

--- a/packages/specz.py
+++ b/packages/specz.py
@@ -15,6 +15,7 @@ Public API:
 # -----------------------
 import ast as _ast
 import difflib
+import json
 import logging
 import os
 import re
@@ -37,6 +38,12 @@ os.environ.setdefault("DASK_DISTRIBUTED__SHUFFLE__METHOD", "tasks")
 # Project (lsdb/hats/CRC)
 # -----------------------
 import hats  # noqa: F401
+from deduplication import (
+    _INSTRUMENT_TYPE_TO_INCLUDE_KEY,
+    _OBJECT_TYPE_TO_INCLUDE_KEY,
+    validate_instrument_type_inclusion,
+    validate_object_type_inclusion,
+)
 from product_handle import (
     ProductHandle,
 )
@@ -73,6 +80,12 @@ else:
     DTYPE_INT = "Int64"
     DTYPE_BOOL = "boolean"
     DTYPE_INT8 = "Int8"
+
+HOMOGENIZED_COLUMNS = (
+    "z_flag_homogenized",
+    "instrument_type_homogenized",
+    "object_type_homogenized",
+)
 
 # -----------------------
 # Module exports & constants
@@ -1678,6 +1691,73 @@ def build_runtime_schema_hints(
     return hints
 
 
+def _normalize_output_homogenized_columns_config(config: object) -> dict[str, str]:
+    """Return output policy for homogenized columns."""
+    valid = {"auto", "always", "never"}
+    if config is None:
+        supplied = {}
+    elif isinstance(config, dict):
+        supplied = dict(config)
+    else:
+        raise TypeError("param.output_homogenized_columns must be a mapping")
+
+    unknown = sorted(set(supplied) - set(HOMOGENIZED_COLUMNS))
+    if unknown:
+        raise ValueError(f"Unknown output_homogenized_columns option(s): {unknown}")
+
+    result = {column: "always" for column in HOMOGENIZED_COLUMNS}
+    for column, value in supplied.items():
+        normalized = str(value).strip().lower()
+        if normalized not in valid:
+            raise ValueError(
+                f"param.output_homogenized_columns.{column} must be one of "
+                f"{sorted(valid)}"
+            )
+        result[column] = normalized
+    return result
+
+
+def _active_z_flag_filter(param_config: dict) -> bool:
+    try:
+        cut_value = float(param_config.get("z_flag_homogenized_value_to_cut"))
+    except (TypeError, ValueError):
+        return False
+    return cut_value in {1.0, 2.0, 3.0, 4.0}
+
+
+def _active_object_type_filter(param_config: dict) -> bool:
+    inclusion = validate_object_type_inclusion(
+        {
+            key: param_config[key]
+            for key in (
+                "include_unclassified_oth",
+                "include_galaxy_oth",
+                "include_star_oth",
+                "include_agn_oth",
+                "include_qso_oth",
+                "include_galactic_oth",
+            )
+            if key in param_config
+        }
+    )
+    return not all(inclusion.values())
+
+
+def _homogenized_columns_used_by_runtime(
+    *,
+    param_config: dict,
+    tiebreaking_priority: list,
+) -> set[str]:
+    used = set(tiebreaking_priority or []) & set(HOMOGENIZED_COLUMNS)
+    if _active_z_flag_filter(param_config):
+        used.add("z_flag_homogenized")
+    if _active_instrument_type_filter(param_config):
+        used.add("instrument_type_homogenized")
+    if _active_object_type_filter(param_config):
+        used.add("object_type_homogenized")
+    return used
+
+
 def _copy_extra_columns_from_sources(
     df: dd.DataFrame,
     columns: dict[str, dict[str, str]],
@@ -2183,6 +2263,7 @@ def _select_output_columns(
     translation_rules_uc: dict,
     tiebreaking_priority: list,
     used_type_fastpath: bool,
+    param_config: dict | None = None,
     save_expr_columns: bool = False,
     schema_hints: dict | None = None,
     extra_columns: dict[str, dict[str, str]] | None = None,
@@ -2194,6 +2275,7 @@ def _select_output_columns(
       translation_rules_uc: Upper-cased translation rules.
       tiebreaking_priority: Priority columns to append if present.
       used_type_fastpath: Whether `type` was reused for instrument_type.
+      param_config: Pipeline ``param`` configuration.
       save_expr_columns: Keep variables used in YAML expressions.
       schema_hints: Normalized hints {'int','float','str','bool'}.
       extra_columns: Configured columns to preserve or create as typed nulls.
@@ -2221,14 +2303,19 @@ def _select_output_columns(
         "group_id",
     ]
 
-    # Homogenized object type is part of every output, including all-null catalogs.
-    final_cols.append("object_type_homogenized")
-
-    # Optional homogenized fields used by the legacy quality/ranking logic.
-    if "z_flag_homogenized" in df.columns:
-        final_cols.append("z_flag_homogenized")
-    if "instrument_type_homogenized" in df.columns:
-        final_cols.append("instrument_type_homogenized")
+    param_config = param_config or {}
+    homogenized_output = _normalize_output_homogenized_columns_config(
+        param_config.get("output_homogenized_columns")
+    )
+    runtime_used_homogenized = _homogenized_columns_used_by_runtime(
+        param_config=param_config,
+        tiebreaking_priority=tiebreaking_priority,
+    )
+    for column in HOMOGENIZED_COLUMNS:
+        policy = homogenized_output[column]
+        keep_auto = policy == "auto" and column in runtime_used_homogenized
+        if column in df.columns and (policy == "always" or keep_auto):
+            final_cols.append(column)
 
     # Normalize compared_to to nullable string if present.
     if "compared_to" in df.columns:
@@ -2242,7 +2329,11 @@ def _select_output_columns(
         df["instrument_type"] = df["type"].astype(DTYPE_STR)
 
     # Add tiebreaking columns if present and not already included.
-    extra = [c for c in tiebreaking_priority if c not in final_cols and c in df.columns]
+    extra = [
+        c
+        for c in tiebreaking_priority
+        if c not in final_cols and c in df.columns and c not in HOMOGENIZED_COLUMNS
+    ]
     final_cols += extra
 
     # Collect variables referenced in YAML expressions (if requested).
@@ -2391,6 +2482,219 @@ def _requires_z_flag_homogenization(combine_mode: str, cut_value: object) -> boo
     return numeric_cut in {1.0, 2.0, 3.0, 4.0}
 
 
+def _active_instrument_type_filter(param_config: dict) -> bool:
+    inclusion = validate_instrument_type_inclusion(
+        {
+            key: param_config[key]
+            for key in (
+                "include_spectroscopic_ith",
+                "include_grism_ith",
+                "include_photometric_ith",
+                "include_unclassified_ith",
+            )
+            if key in param_config
+        }
+    )
+    return not all(inclusion.values())
+
+
+def _filter_empty_result(
+    df: dd.DataFrame,
+    *,
+    product_name: str,
+    temp_dir: str,
+    reason: str,
+    detail_lines: list[str],
+    logger: logging.LoggerAdapter | logging.Logger,
+) -> tuple[dd.DataFrame, bool]:
+    final_count = int(df.map_partitions(len).sum().compute())
+    if final_count > 0:
+        return df, False
+
+    marker_path = os.path.join(temp_dir, f"prepared_{product_name}.empty")
+    try:
+        with open(marker_path, "w", encoding="utf-8") as fp:
+            fp.write(f"{reason}\n")
+            fp.write(f"product={product_name}\n")
+            for line in detail_lines:
+                fp.write(f"{line}\n")
+            fp.write("rows_after=0\n")
+    except Exception as e:
+        logger.warning("Could not write empty-catalog marker %s: %s", marker_path, e)
+
+    logger.warning(
+        "[%s] Catalog is empty after preparation filters (%s); excluding it from "
+        "subsequent HATS, crossmatch, and deduplication steps.",
+        product_name,
+        reason,
+    )
+    return df, True
+
+
+def _apply_object_type_filter(
+    df: dd.DataFrame,
+    *,
+    param_config: dict,
+    product_name: str,
+    temp_dir: str,
+    logger: logging.LoggerAdapter | logging.Logger,
+) -> tuple[dd.DataFrame, bool]:
+    inclusion = validate_object_type_inclusion(
+        {
+            key: param_config[key]
+            for key in (
+                "include_unclassified_oth",
+                "include_galaxy_oth",
+                "include_star_oth",
+                "include_agn_oth",
+                "include_qso_oth",
+                "include_galactic_oth",
+            )
+            if key in param_config
+        }
+    )
+    if all(inclusion.values()):
+        return df, False
+
+    normalized = df["object_type_homogenized"].astype("string").str.strip().str.lower()
+    keep = normalized.map_partitions(
+        lambda series: pd.Series(False, index=series.index),
+        meta=pd.Series(dtype=bool),
+    )
+    if inclusion["include_unclassified_oth"]:
+        keep = keep | normalized.isna()
+    for object_type, key in _OBJECT_TYPE_TO_INCLUDE_KEY.items():
+        if inclusion[key]:
+            keep = keep | normalized.eq(object_type).fillna(False)
+
+    out = df[keep]
+    retained = int(out.map_partitions(len).sum().compute())
+    logger.info(
+        "[%s] Applied object_type_homogenized filter: %s rows retained; inclusion=%s",
+        product_name,
+        retained,
+        inclusion,
+    )
+    return _filter_empty_result(
+        out,
+        product_name=product_name,
+        temp_dir=temp_dir,
+        reason="empty_after_object_type_homogenized_filter",
+        detail_lines=[f"object_type_inclusion={inclusion}"],
+        logger=logger,
+    )
+
+
+def _apply_instrument_type_filter(
+    df: dd.DataFrame,
+    *,
+    param_config: dict,
+    product_name: str,
+    temp_dir: str,
+    logger: logging.LoggerAdapter | logging.Logger,
+) -> tuple[dd.DataFrame, bool]:
+    inclusion = validate_instrument_type_inclusion(
+        {
+            key: param_config[key]
+            for key in (
+                "include_spectroscopic_ith",
+                "include_grism_ith",
+                "include_photometric_ith",
+                "include_unclassified_ith",
+            )
+            if key in param_config
+        }
+    )
+    if all(inclusion.values()):
+        return df, False
+
+    normalized = (
+        df["instrument_type_homogenized"].astype("string").str.strip().str.lower()
+    )
+    keep = normalized.map_partitions(
+        lambda series: pd.Series(False, index=series.index),
+        meta=pd.Series(dtype=bool),
+    )
+    if inclusion["include_unclassified_ith"]:
+        keep = keep | normalized.isna()
+    for instrument_type, key in _INSTRUMENT_TYPE_TO_INCLUDE_KEY.items():
+        if inclusion[key]:
+            keep = keep | normalized.eq(instrument_type).fillna(False)
+
+    out = df[keep]
+    retained = int(out.map_partitions(len).sum().compute())
+    logger.info(
+        "[%s] Applied instrument_type_homogenized filter: %s rows retained; inclusion=%s",
+        product_name,
+        retained,
+        inclusion,
+    )
+    return _filter_empty_result(
+        out,
+        product_name=product_name,
+        temp_dir=temp_dir,
+        reason="empty_after_instrument_type_homogenized_filter",
+        detail_lines=[f"instrument_type_inclusion={inclusion}"],
+        logger=logger,
+    )
+
+
+def _required_homogenized_columns(
+    *,
+    param_config: dict,
+    tiebreaking_priority: list,
+) -> dict[str, list[str]]:
+    required: dict[str, list[str]] = {column: [] for column in HOMOGENIZED_COLUMNS}
+    priority_set = set(tiebreaking_priority or [])
+    for column in HOMOGENIZED_COLUMNS:
+        if column in priority_set:
+            required[column].append("tiebreaking_priority")
+    if _active_z_flag_filter(param_config):
+        required["z_flag_homogenized"].append("z_flag_homogenized_value_to_cut")
+    if _active_instrument_type_filter(param_config):
+        required["instrument_type_homogenized"].append("instrument_type_filter")
+    if _active_object_type_filter(param_config):
+        required["object_type_homogenized"].append("object_type_filter")
+    return {column: reasons for column, reasons in required.items() if reasons}
+
+
+def _write_homogenized_metadata(
+    df: dd.DataFrame,
+    *,
+    product_name: str,
+    temp_dir: str,
+    required_columns: dict[str, list[str]],
+    logger: logging.LoggerAdapter | logging.Logger,
+) -> dict:
+    counts = {}
+    for column in HOMOGENIZED_COLUMNS:
+        counts[column] = int(df[column].count().compute()) if column in df.columns else 0
+
+    metadata = {
+        "product": product_name,
+        "homogenized_non_null_counts": counts,
+        "required_homogenized_columns": required_columns,
+    }
+    marker_path = os.path.join(temp_dir, f"prepared_{product_name}.homogenized.json")
+    try:
+        with open(marker_path, "w", encoding="utf-8") as fp:
+            json.dump(metadata, fp, indent=2, sort_keys=True)
+    except Exception as e:
+        logger.warning("Could not write homogenized metadata %s: %s", marker_path, e)
+
+    for column, reasons in required_columns.items():
+        if counts.get(column, 0) == 0:
+            logger.warning(
+                "[%s] Required homogenized column '%s' has no non-null values "
+                "in this catalog; reasons=%s. The driver will fail if this is "
+                "true for all input catalogs.",
+                product_name,
+                column,
+                reasons,
+            )
+    return metadata
+
+
 def validate_combine_configuration(
     combine_mode: object,
     tiebreaking_priority: object,
@@ -2525,7 +2829,7 @@ def prepare_catalog(
     extra_columns = _normalize_extra_columns_config(param_config.get("extra_columns"))
 
     z_flag_homogenized_value_to_cut = param_config.get(
-        "z_flag_homogenized_value_to_cut", None
+        "z_flag_homogenized_value_to_cut", 0
     )
 
     # 1) Load product
@@ -2566,12 +2870,26 @@ def prepare_catalog(
             combine_mode,
             z_flag_homogenized_value_to_cut,
         ),
+        require_instrument_type_homogenized=_active_instrument_type_filter(
+            param_config
+        ),
     )
     df = _normalize_custom_tiebreaking_priorities(
         df,
         list(tiebreaking_priority),
         product_name,
         lg,
+    )
+    required_homogenized = _required_homogenized_columns(
+        param_config=param_config,
+        tiebreaking_priority=list(tiebreaking_priority),
+    )
+    _write_homogenized_metadata(
+        df,
+        product_name=product_name,
+        temp_dir=temp_dir,
+        required_columns=required_homogenized,
+        logger=lg,
     )
 
     # 7) Apply cut based on z_flag_homogenized if requested
@@ -2605,35 +2923,41 @@ def prepare_catalog(
                     cut_val,
                     final_count,
                 )
-                if final_count == 0:
-                    marker_path = os.path.join(
-                        temp_dir, f"prepared_{product_name}.empty"
-                    )
-                    try:
-                        with open(marker_path, "w", encoding="utf-8") as fp:
-                            fp.write(
-                                "empty_after_z_flag_homogenized_cut\n"
-                                f"product={product_name}\n"
-                                f"z_flag_homogenized_value_to_cut={cut_val}\n"
-                                "rows_after=0\n"
-                            )
-                    except Exception as e:
-                        lg.warning(
-                            "Could not write empty-catalog marker %s: %s",
-                            marker_path,
-                            e,
-                        )
-                    lg.warning(
-                        "[%s] Catalog is empty after z_flag_homogenized cut >= %s; "
-                        "excluding it from subsequent HATS, crossmatch, and "
-                        "deduplication steps.",
-                        product_name,
-                        cut_val,
-                    )
+                _, empty_after_filter = _filter_empty_result(
+                    df,
+                    product_name=product_name,
+                    temp_dir=temp_dir,
+                    reason="empty_after_z_flag_homogenized_cut",
+                    detail_lines=[f"z_flag_homogenized_value_to_cut={cut_val}"],
+                    logger=lg,
+                )
+                if empty_after_filter:
                     lg.info(
                         f"END prepare_catalog product={product_name} empty_after_cut"
                     )
                     return "", "ra", "dec", product_name, "empty_after_cut"
+
+    df, empty_after_filter = _apply_instrument_type_filter(
+        df,
+        param_config=param_config,
+        product_name=product_name,
+        temp_dir=temp_dir,
+        logger=lg,
+    )
+    if empty_after_filter:
+        lg.info(f"END prepare_catalog product={product_name} empty_after_filter")
+        return "", "ra", "dec", product_name, "empty_after_filter"
+
+    df, empty_after_filter = _apply_object_type_filter(
+        df,
+        param_config=param_config,
+        product_name=product_name,
+        temp_dir=temp_dir,
+        logger=lg,
+    )
+    if empty_after_filter:
+        lg.info(f"END prepare_catalog product={product_name} empty_after_filter")
+        return "", "ra", "dec", product_name, "empty_after_filter"
 
     # 8) Optional persist + repartition. Sizing by bytes requires another full
     # pass, so production keeps the existing partitions unless explicitly asked.
@@ -2690,6 +3014,7 @@ def prepare_catalog(
         translation_rules_uc,
         tiebreaking_priority,
         used_type_fastpath,
+        param_config,
         save_expr_columns=translation_config.get("save_expr_columns", False),
         schema_hints=_normalize_schema_hints(
             translation_config.get("expr_column_schema")

--- a/packages/specz.py
+++ b/packages/specz.py
@@ -1985,6 +1985,12 @@ CRD_ID_OPTIONAL_HASH_COLUMNS = (
 CRD_ID_HASH_COLUMNS = CRD_ID_REQUIRED_HASH_COLUMNS + CRD_ID_OPTIONAL_HASH_COLUMNS
 
 
+def _crd_id_diagnostic_columns(columns: Sequence[str]) -> list[str]:
+    """Return stable columns to show when CRD_ID collisions are detected."""
+    wanted = ("CRD_ID",) + CRD_ID_HASH_COLUMNS
+    return [column for column in wanted if column in columns]
+
+
 def _format_crd_signature_value(value: object) -> str:
     """Return a stable scalar representation for CRD_ID hashing."""
     if pd.isna(value):
@@ -2064,6 +2070,54 @@ def _generate_crd_ids(
     )
 
 
+def _log_crd_id_collision_diagnostics(
+    df: dd.DataFrame,
+    product_name: str,
+    logger: logging.LoggerAdapter,
+    *,
+    duplicate_rows: int,
+    max_groups: int = 5,
+    max_rows: int = 50,
+) -> None:
+    """Log a bounded sample of duplicate CRD_ID groups before failing."""
+    try:
+        counts = df.groupby("CRD_ID").size().rename("_count").reset_index()
+        duplicate_counts = counts[counts["_count"] > 1]
+        duplicate_summary = duplicate_counts.sort_values(
+            "_count", ascending=False
+        ).head(max_groups, npartitions=-1)
+        if duplicate_summary.empty:
+            logger.error(
+                "%s CRD_ID collision diagnostics found duplicate_rows=%d but no "
+                "duplicate groups were sampled.",
+                product_name,
+                duplicate_rows,
+            )
+            return
+
+        sample_ids = duplicate_summary["CRD_ID"].astype(str).tolist()
+        diagnostic_columns = _crd_id_diagnostic_columns(df.columns)
+        sample_rows = (
+            df.loc[df["CRD_ID"].isin(sample_ids), diagnostic_columns]
+            .head(max_rows, npartitions=-1)
+            .to_dict("records")
+        )
+        logger.error(
+            "%s CRD_ID collision diagnostics: duplicate_rows=%d "
+            "sample_groups=%s sample_rows=%s",
+            product_name,
+            duplicate_rows,
+            duplicate_summary.to_dict("records"),
+            sample_rows,
+        )
+    except Exception as exc:
+        logger.error(
+            "%s CRD_ID collision diagnostics failed: %r",
+            product_name,
+            exc,
+        )
+
+
 def _validate_unique_crd_ids(
     df: dd.DataFrame, product_name: str, logger: logging.LoggerAdapter
 ) -> None:
@@ -2076,6 +2130,9 @@ def _validate_unique_crd_ids(
     unique_ids = int(unique_ids)
     duplicate_rows = total_rows - unique_ids
     if duplicate_rows:
+        _log_crd_id_collision_diagnostics(
+            df, product_name, logger, duplicate_rows=duplicate_rows
+        )
         raise RuntimeError(
             f"{product_name}: generated non-unique CRD_ID values "
             f"(rows={total_rows}, unique_ids={unique_ids}, "

--- a/packages/specz_homogenization.py
+++ b/packages/specz_homogenization.py
@@ -174,6 +174,44 @@ def validate_translation_config(config: dict) -> None:
     unknown_top = set(config) - _TOP_LEVEL_KEYS
     if unknown_top:
         raise ValueError(f"flags translation root: unknown option(s): {sorted(unknown_top)}")
+    required_top = {
+        "translation_rules",
+        "tiebreaking_priority",
+        "instrument_type_priority",
+        "expr_column_schema",
+    }
+    missing_top = sorted(required_top - set(config))
+    if missing_top:
+        raise ValueError(
+            "flags translation root: missing required scientific option(s): "
+            f"{missing_top}"
+        )
+    priorities = config.get("tiebreaking_priority")
+    if not isinstance(priorities, list):
+        raise TypeError("tiebreaking_priority must be a list")
+    if any(not isinstance(column, str) or not column.strip() for column in priorities):
+        raise ValueError("tiebreaking_priority entries must be non-empty strings")
+    if len(set(priorities)) != len(priorities):
+        raise ValueError("tiebreaking_priority cannot contain duplicate columns")
+
+    instrument_priority = config.get("instrument_type_priority")
+    if not isinstance(instrument_priority, dict):
+        raise TypeError("instrument_type_priority must be a mapping")
+    if not instrument_priority:
+        raise ValueError("instrument_type_priority must not be empty")
+    for label, priority in instrument_priority.items():
+        if label not in {"s", "g", "p"}:
+            raise ValueError(
+                f"instrument_type_priority.{label!r} is invalid; expected s, g or p"
+            )
+        if (
+            not isinstance(priority, int)
+            or isinstance(priority, bool)
+            or priority < 1
+        ):
+            raise ValueError(
+                f"instrument_type_priority.{label} must be a positive integer"
+            )
     for key in (
         "tie_invariant_diagnostics_enabled",
         "tie_invariant_diagnostics_detailed_enabled",
@@ -200,7 +238,18 @@ def validate_translation_config(config: dict) -> None:
         raise ValueError(
             "max_representative_radius_arcsec must be a positive number or null"
         )
-    rules = config.get("translation_rules", {})
+    rules = config.get("translation_rules")
+    expr_schema = config.get("expr_column_schema")
+    if not isinstance(expr_schema, dict):
+        raise TypeError("expr_column_schema must be a mapping")
+    for column, kind in expr_schema.items():
+        if not isinstance(column, str) or not column.strip():
+            raise ValueError("expr_column_schema column names must be non-empty strings")
+        if kind not in {"str", "float", "int", "bool"}:
+            raise ValueError(
+                f"expr_column_schema.{column}={kind!r} is invalid; "
+                "expected str, float, int or bool"
+            )
     runtime_hints = config.get("runtime_schema_hints", {})
     if not isinstance(runtime_hints, dict):
         raise TypeError("runtime_schema_hints must be a mapping")
@@ -214,6 +263,8 @@ def validate_translation_config(config: dict) -> None:
             )
     if not isinstance(rules, dict):
         raise TypeError("translation_rules must be a mapping")
+    if not rules:
+        raise ValueError("translation_rules must not be empty")
     for survey, ruleset in rules.items():
         base = f"translation_rules.{survey}"
         if not isinstance(survey, str) or not survey.strip():
@@ -435,6 +486,7 @@ def _homogenize(
     type_cast_ok: bool,
     *,
     require_z_flag_homogenized: bool = False,
+    require_instrument_type_homogenized: bool = False,
 ) -> tuple[dd.DataFrame, bool, list, dict, dict]:
     """Compute homogenized columns for tie-breaking.
 
@@ -446,6 +498,8 @@ def _homogenize(
         type_cast_ok: Whether `type` was normalized.
         require_z_flag_homogenized: Create and validate the quality flag even
             when it is not a ranking priority.
+        require_instrument_type_homogenized: Create and validate the instrument
+            type even when it is not a ranking priority.
 
     Returns:
         Tuple: (df, used_type_fastpath, tiebreaking_priority, instrument_type_priority, translation_rules_uc)
@@ -457,6 +511,10 @@ def _homogenize(
     validated_non_null_counts: dict[str, int] = {}
     z_flag_is_priority = "z_flag_homogenized" in tiebreaking_priority
     needs_z_flag = z_flag_is_priority or require_z_flag_homogenized
+    instrument_type_is_priority = "instrument_type_homogenized" in tiebreaking_priority
+    needs_instrument_type = (
+        instrument_type_is_priority or require_instrument_type_homogenized
+    )
 
     def _fast_path_policy(key: str) -> str:
         if "survey" not in df.columns:
@@ -507,7 +565,14 @@ def _homogenize(
     # -----------------------
     # Vectorized translator
     # -----------------------
-    def _translate_column_vectorized(df: dd.DataFrame, key: str, out_col: str, out_kind: str) -> dd.DataFrame:
+    def _translate_column_vectorized(
+        df: dd.DataFrame,
+        key: str,
+        out_col: str,
+        out_kind: str,
+        *,
+        strict: bool = True,
+    ) -> dd.DataFrame:
         """Apply YAML translation rules per partition."""
         assert key in {"z_flag", "instrument_type", "object_type"}
         assert out_col in {
@@ -630,6 +695,8 @@ def _homogenize(
                 if direct:
                     if source_col not in s.columns:
                         if not optional_source:
+                            if not strict:
+                                continue
                             raise ValueError(
                                 f"Missing source column '{source_col}' for survey "
                                 f"'{sname}' and translation '{out_col}'."
@@ -685,6 +752,17 @@ def _homogenize(
                         expr_vec = _ast.unparse(tree2)
                         mlocal = eval(expr_vec, safe_globals, ctx)
                     except Exception as e:
+                        if not strict:
+                            logger.warning(
+                                "[%s] Skipping optional %s condition '%s' for "
+                                "survey '%s': %s",
+                                product_name,
+                                out_col,
+                                expr,
+                                sname,
+                                e,
+                            )
+                            continue
                         raise ValueError(
                             f"Error evaluating condition '{expr}' for survey "
                             f"'{sname}': {e}"
@@ -775,70 +853,62 @@ def _homogenize(
             return 4.0
         return np.nan
 
-    if needs_z_flag:
-        if "z_flag_homogenized" not in df.columns:
-            z_fast_path = _fast_path_policy("z_flag")
-            z_fast_path_compatible = can_use_zflag_as_quality()
-            if z_fast_path == "required" and not z_fast_path_compatible:
-                raise ValueError(
-                    f"[{product_name}] z_flag fast_path is 'required', but z_flag "
-                    "is not a non-empty probability-like column in [0, 1]"
-                )
-            if z_fast_path != "disabled" and z_fast_path_compatible:
-                logger.info(
-                    "%s Using 'z_flag' fast path for z_flag_homogenized "
-                    "(policy=%s); YAML z_flag rules are bypassed.",
-                    product_name,
-                    z_fast_path,
-                )
-                df["z_flag_homogenized"] = df["z_flag"].map_partitions(
-                    lambda s: s.apply(quality_like_to_flag).astype(DTYPE_FLOAT),
-                    meta=pd.Series(pd.array([], dtype=DTYPE_FLOAT)),
-                )
-            else:
-                logger.info(f"{product_name} Using YAML translation for z_flag_homogenized.")
-                # NEW: assert that all surveys present have YAML coverage for z_flag
-                _assert_yaml_coverage_for_surveys(
-                    df=df,
-                    key="z_flag",
-                    translation_rules_uc=translation_rules_uc,
-                    product_name=product_name,
-                    logger=logger,
-                )
-                df = _translate_column_vectorized(df, key="z_flag",
-                                                  out_col="z_flag_homogenized",
-                                                  out_kind="float")
-                _validate_result_domain(
-                    "z_flag_homogenized", {0.0, 1.0, 2.0, 3.0, 4.0}
-                )
-        else:
-            # User-provided 'z_flag_homogenized' is present. Validate allowed domain {0,1,2,3,4} (NaN allowed).
-            logger.info(f"{product_name} 'z_flag_homogenized' already exists; validating user-provided values.")
-            allowed = {0.0, 1.0, 2.0, 3.0, 4.0}
-
-            vals = dd.to_numeric(df["z_flag_homogenized"], errors="coerce")
-            # NaN is allowed; only non-NaN values outside the allowed set are invalid
-            invalid_mask = (
-                ((~dd.isna(df["z_flag_homogenized"])) & dd.isna(vals))
-                | ((~dd.isna(vals)) & ~vals.isin(list(allowed)))
+    if "z_flag_homogenized" not in df.columns:
+        z_fast_path = _fast_path_policy("z_flag")
+        z_fast_path_compatible = can_use_zflag_as_quality()
+        if z_fast_path == "required" and not z_fast_path_compatible:
+            raise ValueError(
+                f"[{product_name}] z_flag fast_path is 'required', but z_flag "
+                "is not a non-empty probability-like column in [0, 1]"
             )
-            invalid_count, non_null_count = dask.compute(
-                invalid_mask.sum(), vals.count()
+        if z_fast_path != "disabled" and z_fast_path_compatible:
+            logger.info(
+                "%s Using 'z_flag' fast path for z_flag_homogenized "
+                "(policy=%s); YAML z_flag rules are bypassed.",
+                product_name,
+                z_fast_path,
             )
-            validated_non_null_counts["z_flag_homogenized"] = int(non_null_count)
-
-            if invalid_count > 0:
-                examples = df["z_flag_homogenized"].loc[invalid_mask].head(5, compute=True).tolist()
-                raise ValueError(
-                    f"[{product_name}] Invalid values in user-provided 'z_flag_homogenized'. "
-                    f"Allowed set is {sorted(allowed)} (NaN allowed). Examples of invalid values: {examples}"
-                )
-
-            # Cast to Arrow-backed float dtype for consistency
-            df["z_flag_homogenized"] = vals.map_partitions(
-                lambda s: s.astype(DTYPE_FLOAT),
+            df["z_flag_homogenized"] = df["z_flag"].map_partitions(
+                lambda s: s.apply(quality_like_to_flag).astype(DTYPE_FLOAT),
                 meta=pd.Series(pd.array([], dtype=DTYPE_FLOAT)),
             )
+        else:
+            logger.info(f"{product_name} Using YAML translation for z_flag_homogenized.")
+            df = _translate_column_vectorized(df, key="z_flag",
+                                              out_col="z_flag_homogenized",
+                                              out_kind="float",
+                                              strict=needs_z_flag)
+            _validate_result_domain(
+                "z_flag_homogenized", {0.0, 1.0, 2.0, 3.0, 4.0}
+            )
+    else:
+        # User-provided 'z_flag_homogenized' is present. Validate allowed domain {0,1,2,3,4} (NaN allowed).
+        logger.info(f"{product_name} 'z_flag_homogenized' already exists; validating user-provided values.")
+        allowed = {0.0, 1.0, 2.0, 3.0, 4.0}
+
+        vals = dd.to_numeric(df["z_flag_homogenized"], errors="coerce")
+        # NaN is allowed; only non-NaN values outside the allowed set are invalid
+        invalid_mask = (
+            ((~dd.isna(df["z_flag_homogenized"])) & dd.isna(vals))
+            | ((~dd.isna(vals)) & ~vals.isin(list(allowed)))
+        )
+        invalid_count, non_null_count = dask.compute(
+            invalid_mask.sum(), vals.count()
+        )
+        validated_non_null_counts["z_flag_homogenized"] = int(non_null_count)
+
+        if invalid_count > 0:
+            examples = df["z_flag_homogenized"].loc[invalid_mask].head(5, compute=True).tolist()
+            raise ValueError(
+                f"[{product_name}] Invalid values in user-provided 'z_flag_homogenized'. "
+                f"Allowed set is {sorted(allowed)} (NaN allowed). Examples of invalid values: {examples}"
+            )
+
+        # Cast to Arrow-backed float dtype for consistency
+        df["z_flag_homogenized"] = vals.map_partitions(
+            lambda s: s.astype(DTYPE_FLOAT),
+            meta=pd.Series(pd.array([], dtype=DTYPE_FLOAT)),
+        )
 
 
     # instrument_type_homogenized
@@ -858,76 +928,68 @@ def _homogenize(
             logger.warning(f"{product_name} Could not validate 'type' values: {e}")
             return False
 
-    if "instrument_type_homogenized" in tiebreaking_priority:
-        if "instrument_type_homogenized" not in df.columns:
-            instrument_fast_path = _fast_path_policy("instrument_type")
-            instrument_fast_path_compatible = can_use_type_for_instrument()
-            if instrument_fast_path == "required" and not instrument_fast_path_compatible:
-                raise ValueError(
-                    f"[{product_name}] instrument_type fast_path is 'required', "
-                    "but type is not a non-empty column containing only s/g/p"
-                )
-            if instrument_fast_path != "disabled" and instrument_fast_path_compatible:
-                logger.info(
-                    "%s Using 'type' fast path for instrument_type_homogenized "
-                    "(policy=%s); YAML instrument rules are bypassed.",
-                    product_name,
-                    instrument_fast_path,
-                )
-                df["instrument_type_homogenized"] = df["type"].map_partitions(
-                    _normalize_string_series_to_na,
-                    meta=pd.Series(pd.array([], dtype=DTYPE_STR)),
-                ).str.lower()
-                used_type_fastpath = True
-            else:
-                logger.info(f"{product_name} Using YAML translation for instrument_type_homogenized.")
-                # NEW: assert that all surveys present have YAML coverage for instrument_type
-                _assert_yaml_coverage_for_surveys(
-                    df=df,
-                    key="instrument_type",
-                    translation_rules_uc=translation_rules_uc,
-                    product_name=product_name,
-                    logger=logger,
-                )
-                df = _translate_column_vectorized(df, key="instrument_type",
-                                                  out_col="instrument_type_homogenized",
-                                                  out_kind="str")
-                df["instrument_type_homogenized"] = df["instrument_type_homogenized"].map_partitions(
-                    _normalize_string_series_to_na,
-                    meta=pd.Series(pd.array([], dtype=DTYPE_STR)),
-                ).str.lower()
-                _validate_result_domain(
-                    "instrument_type_homogenized",
-                    {"s", "g", "p"},
-                    normalize_string=True,
-                )
-        else:
-            # User-provided 'instrument_type_homogenized' is present. Validate allowed domain {"s","p","g"}.
-            logger.info(f"{product_name} 'instrument_type_homogenized' already exists; validating user-provided values.")
-            allowed = {"s", "p", "g"}
-
-            normed = df["instrument_type_homogenized"].map_partitions(
+    if "instrument_type_homogenized" not in df.columns:
+        instrument_fast_path = _fast_path_policy("instrument_type")
+        instrument_fast_path_compatible = can_use_type_for_instrument()
+        if instrument_fast_path == "required" and not instrument_fast_path_compatible:
+            raise ValueError(
+                f"[{product_name}] instrument_type fast_path is 'required', "
+                "but type is not a non-empty column containing only s/g/p"
+            )
+        if instrument_fast_path != "disabled" and instrument_fast_path_compatible:
+            logger.info(
+                "%s Using 'type' fast path for instrument_type_homogenized "
+                "(policy=%s); YAML instrument rules are bypassed.",
+                product_name,
+                instrument_fast_path,
+            )
+            df["instrument_type_homogenized"] = df["type"].map_partitions(
                 _normalize_string_series_to_na,
                 meta=pd.Series(pd.array([], dtype=DTYPE_STR)),
             ).str.lower()
-
-            invalid_mask = (~dd.isna(normed)) & ~normed.isin(list(allowed))
-            invalid_count, non_null_count = dask.compute(
-                invalid_mask.sum(), normed.count()
+            used_type_fastpath = True
+        else:
+            logger.info(f"{product_name} Using YAML translation for instrument_type_homogenized.")
+            df = _translate_column_vectorized(df, key="instrument_type",
+                                              out_col="instrument_type_homogenized",
+                                              out_kind="str",
+                                              strict=needs_instrument_type)
+            df["instrument_type_homogenized"] = df["instrument_type_homogenized"].map_partitions(
+                _normalize_string_series_to_na,
+                meta=pd.Series(pd.array([], dtype=DTYPE_STR)),
+            ).str.lower()
+            _validate_result_domain(
+                "instrument_type_homogenized",
+                {"s", "g", "p"},
+                normalize_string=True,
             )
-            validated_non_null_counts["instrument_type_homogenized"] = int(
-                non_null_count
+    else:
+        # User-provided 'instrument_type_homogenized' is present. Validate allowed domain {"s","p","g"}.
+        logger.info(f"{product_name} 'instrument_type_homogenized' already exists; validating user-provided values.")
+        allowed = {"s", "p", "g"}
+
+        normed = df["instrument_type_homogenized"].map_partitions(
+            _normalize_string_series_to_na,
+            meta=pd.Series(pd.array([], dtype=DTYPE_STR)),
+        ).str.lower()
+
+        invalid_mask = (~dd.isna(normed)) & ~normed.isin(list(allowed))
+        invalid_count, non_null_count = dask.compute(
+            invalid_mask.sum(), normed.count()
+        )
+        validated_non_null_counts["instrument_type_homogenized"] = int(
+            non_null_count
+        )
+
+        if invalid_count > 0:
+            examples = df["instrument_type_homogenized"].loc[invalid_mask].head(5, compute=True).tolist()
+            raise ValueError(
+                f"[{product_name}] Invalid values in user-provided 'instrument_type_homogenized'. "
+                f"Allowed set is {sorted(allowed)}. Examples of invalid values: {examples}"
             )
 
-            if invalid_count > 0:
-                examples = df["instrument_type_homogenized"].loc[invalid_mask].head(5, compute=True).tolist()
-                raise ValueError(
-                    f"[{product_name}] Invalid values in user-provided 'instrument_type_homogenized'. "
-                    f"Allowed set is {sorted(allowed)}. Examples of invalid values: {examples}"
-                )
-
-            # Keep normalized lower-case values for consistency
-            df["instrument_type_homogenized"] = normed
+        # Keep normalized lower-case values for consistency
+        df["instrument_type_homogenized"] = normed
 
     # object_type_homogenized is an output-schema field, not a ranking field.
     # An entirely-null result is valid for catalogs without classification data.
@@ -972,7 +1034,7 @@ def _homogenize(
         # An all-null quality column is valid: this priority simply cannot
         # distinguish candidates. Later priorities or hard-tie handling apply.
 
-    if "instrument_type_homogenized" in tiebreaking_priority:
+    if instrument_type_is_priority:
         if "instrument_type_homogenized" not in df.columns:
             raise ValueError(
                 f"[{product_name}] 'instrument_type_homogenized' is required by tiebreaking_priority but is missing after homogenization."
@@ -981,10 +1043,10 @@ def _homogenize(
         if non_null is None:
             non_null = dask.compute(df["instrument_type_homogenized"].count())[0]
         if int(non_null) == 0:
-            raise ValueError(
+            logger.warning(
                 f"[{product_name}] All values in 'instrument_type_homogenized' are NaN. "
-                "This column is required (in tiebreaking_priority) and must contain at least one non-NaN value. "
-                "Verify YAML translations / fast-path logic and input columns."
+                "This column is required in tiebreaking_priority; the driver will "
+                "fail if all input catalogs have no valid values."
             )
 
     return df, used_type_fastpath, tiebreaking_priority, instrument_type_priority, translation_rules_uc

--- a/packages/specz_homogenization.py
+++ b/packages/specz_homogenization.py
@@ -462,6 +462,7 @@ def _homogenize(
     *,
     require_z_flag_homogenized: bool = False,
     require_instrument_type_homogenized: bool = False,
+    require_object_type_homogenized: bool = False,
 ) -> tuple[dd.DataFrame, bool, list, dict, dict]:
     """Compute homogenized columns for tie-breaking.
 
@@ -475,6 +476,8 @@ def _homogenize(
             when it is not a ranking priority.
         require_instrument_type_homogenized: Create and validate the instrument
             type even when it is not a ranking priority.
+        require_object_type_homogenized: Create and validate the object type
+            for active filters even when it is not a ranking priority.
 
     Returns:
         Tuple: (df, used_type_fastpath, tiebreaking_priority, instrument_type_priority, translation_rules_uc)
@@ -490,6 +493,7 @@ def _homogenize(
     needs_instrument_type = (
         instrument_type_is_priority or require_instrument_type_homogenized
     )
+    needs_object_type = require_object_type_homogenized
 
     def _fast_path_policy(key: str) -> str:
         if "survey" not in df.columns:
@@ -558,7 +562,7 @@ def _homogenize(
         assert out_kind in {"float", "str"}
 
         def _partition(p: pd.DataFrame) -> pd.DataFrame:
-            if p.empty or ("survey" not in p.columns) or (key not in p.columns):
+            if p.empty or ("survey" not in p.columns):
                 q = p.copy()
                 if out_kind == "float":
                     q[out_col] = pd.Series(pd.array([], dtype=DTYPE_FLOAT)).reindex(q.index)
@@ -974,6 +978,7 @@ def _homogenize(
             key="object_type",
             out_col="object_type_homogenized",
             out_kind="str",
+            strict=needs_object_type,
         )
 
     object_types = df["object_type_homogenized"].map_partitions(

--- a/packages/specz_homogenization.py
+++ b/packages/specz_homogenization.py
@@ -85,18 +85,10 @@ _TOP_LEVEL_KEYS = {
     "max_representative_radius_arcsec",
     "margin_threshold_arcsec", "margin_warning_fraction",
     "validate_global_graph_edges", "validate_global_tie_invariants",
-    "validate_crd_id_uniqueness", "repartition_prepared_catalogs",
-    "prepared_partition_size", "crossmatch_n_neighbors",
+    "validate_crd_id_uniqueness", "crossmatch_n_neighbors",
     "crossmatch_saturation_enabled", "crossmatch_saturation_warn_fraction",
-    "crossmatch_saturation_fail_fraction",
-    "crossmatch_geometry_diagnostics_enabled",
-    "representative_radius_diagnostics_enabled", "dedup_edge_diagnostics_enabled",
-    "tie_invariant_diagnostics_enabled",
-    "tie_invariant_diagnostics_detailed_enabled",
-    "tie_invariant_diagnostics_sample_size",
-    "tie_invariant_diagnostics_max_rows",
-    "label_merge_diagnostics_enabled",
-    "instrument_type_priority", "save_expr_columns", "expr_column_schema",
+    "crossmatch_saturation_fail_fraction", "instrument_type_priority",
+    "expr_column_schema",
     "runtime_schema_hints", "translation_rules",
 }
 _SAFE_FUNCTIONS = {"len", "int", "float", "str"}
@@ -212,23 +204,6 @@ def validate_translation_config(config: dict) -> None:
             raise ValueError(
                 f"instrument_type_priority.{label} must be a positive integer"
             )
-    for key in (
-        "tie_invariant_diagnostics_enabled",
-        "tie_invariant_diagnostics_detailed_enabled",
-        "label_merge_diagnostics_enabled",
-    ):
-        if key in config and not isinstance(config[key], bool):
-            raise TypeError(f"{key} must be a boolean")
-    for key in (
-        "tie_invariant_diagnostics_sample_size",
-        "tie_invariant_diagnostics_max_rows",
-    ):
-        if key in config and (
-            not isinstance(config[key], int)
-            or isinstance(config[key], bool)
-            or config[key] < 1
-        ):
-            raise ValueError(f"{key} must be a positive integer")
     max_radius = config.get("max_representative_radius_arcsec")
     if max_radius is not None and (
         isinstance(max_radius, bool)

--- a/packages/specz_homogenization.py
+++ b/packages/specz_homogenization.py
@@ -91,6 +91,19 @@ _TOP_LEVEL_KEYS = {
     "expr_column_schema",
     "runtime_schema_hints", "translation_rules",
 }
+_RUNTIME_ONLY_KEYS = {
+    "crossmatch_geometry_diagnostics_enabled",
+    "dedup_edge_diagnostics_enabled",
+    "label_merge_diagnostics_enabled",
+    "prepared_partition_size",
+    "repartition_prepared_catalogs",
+    "representative_radius_diagnostics_enabled",
+    "save_expr_columns",
+    "tie_invariant_diagnostics_detailed_enabled",
+    "tie_invariant_diagnostics_enabled",
+    "tie_invariant_diagnostics_max_rows",
+    "tie_invariant_diagnostics_sample_size",
+}
 _SAFE_FUNCTIONS = {"len", "int", "float", "str"}
 _SAFE_NUMPY_FUNCTIONS = {"isfinite", "abs", "trunc"}
 _SAFE_SERIES_METHODS = {"isin", "contains", "strip", "lower"}
@@ -320,6 +333,16 @@ def validate_translation_config(config: dict) -> None:
                         f"{sorted(allowed)} or null"
                     )
 
+
+def _science_translation_config(config: dict) -> dict:
+    """Return the science subset from a runtime translation config."""
+    return {
+        key: value
+        for key, value in (config or {}).items()
+        if key not in _RUNTIME_ONLY_KEYS
+    }
+
+
 # -----------------------
 # Local helper (duplicated to avoid circular dep)
 # -----------------------
@@ -482,7 +505,7 @@ def _homogenize(
     Returns:
         Tuple: (df, used_type_fastpath, tiebreaking_priority, instrument_type_priority, translation_rules_uc)
     """
-    validate_translation_config(translation_config)
+    validate_translation_config(_science_translation_config(translation_config))
     tiebreaking_priority = translation_config.get("tiebreaking_priority", [])
     instrument_type_priority = translation_config.get("instrument_type_priority", {})
     translation_rules_uc = {k.upper(): v for k, v in translation_config.get("translation_rules", {}).items()}

--- a/scripts/crd-run.py
+++ b/scripts/crd-run.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 # -----------------------
 import argparse
 import glob
+import hashlib
 import json
 
 # -----------------------
@@ -110,6 +111,9 @@ TRANSLATION_FALLBACK_DEFAULTS = {
     "validate_global_tie_invariants": True,
     "validate_crd_id_uniqueness": True,
 }
+
+PUBLISH_MAX_ATTEMPTS = 3
+PUBLISH_RETRY_DELAY_SECONDS = 5
 
 
 def _build_runtime_param_config(param_config: dict | None) -> dict:
@@ -794,6 +798,140 @@ def _copy_tree(src_dir: str, dst_dir: str, lg: logging.LoggerAdapter) -> None:
         os.makedirs(tgt_root, exist_ok=True)
         for f in files:
             _copy_file(os.path.join(root, f), os.path.join(tgt_root, f), lg)
+
+
+def _sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify_copied_file(src: str, dst: str) -> None:
+    if not os.path.isfile(src):
+        raise FileNotFoundError(f"source file is missing: {src}")
+    if not os.path.isfile(dst):
+        raise FileNotFoundError(f"destination file is missing: {dst}")
+
+    src_size = os.path.getsize(src)
+    dst_size = os.path.getsize(dst)
+    if src_size != dst_size:
+        raise RuntimeError(
+            "copied file size mismatch: "
+            f"{src} ({src_size} bytes) != {dst} ({dst_size} bytes)"
+        )
+
+    src_hash = _sha256_file(src)
+    dst_hash = _sha256_file(dst)
+    if src_hash != dst_hash:
+        raise RuntimeError(
+            f"copied file checksum mismatch: {src} ({src_hash}) != {dst} ({dst_hash})"
+        )
+
+
+def _verify_copied_tree(src_dir: str, dst_dir: str) -> tuple[int, int]:
+    if not os.path.isdir(src_dir):
+        raise FileNotFoundError(f"source directory is missing: {src_dir}")
+    if not os.path.isdir(dst_dir):
+        raise FileNotFoundError(f"destination directory is missing: {dst_dir}")
+
+    n_dirs = 0
+    n_files = 0
+    for root, dirs, files in os.walk(src_dir):
+        rel = os.path.relpath(root, src_dir)
+        dst_root = os.path.join(dst_dir, rel) if rel != "." else dst_dir
+        if not os.path.isdir(dst_root):
+            raise FileNotFoundError(f"destination directory is missing: {dst_root}")
+        n_dirs += 1
+
+        for dirname in dirs:
+            dst_subdir = os.path.join(dst_root, dirname)
+            if not os.path.isdir(dst_subdir):
+                raise FileNotFoundError(
+                    f"destination directory is missing: {dst_subdir}"
+                )
+
+        for filename in files:
+            src_file = os.path.join(root, filename)
+            dst_file = os.path.join(dst_root, filename)
+            _verify_copied_file(src_file, dst_file)
+            n_files += 1
+
+    return n_dirs, n_files
+
+
+def _verify_publish_artifacts(
+    artifacts: list[tuple[str, str, str]],
+    lg: logging.LoggerAdapter,
+) -> None:
+    """Verify published artifacts against staged sources."""
+    total_files = 0
+    total_dirs = 0
+    for kind, src, dst in artifacts:
+        if kind == "file":
+            _verify_copied_file(src, dst)
+            total_files += 1
+        elif kind == "tree":
+            n_dirs, n_files = _verify_copied_tree(src, dst)
+            total_dirs += n_dirs
+            total_files += n_files
+        else:
+            raise ValueError(f"Unknown publish artifact kind: {kind}")
+
+    lg.info(
+        "Publish verification passed: %d file(s), %d directories verified.",
+        total_files,
+        total_dirs,
+    )
+
+
+def _copy_publish_artifact(
+    kind: str, src: str, dst: str, lg: logging.LoggerAdapter
+) -> None:
+    if kind == "file":
+        _copy_file(src, dst, lg)
+    elif kind == "tree":
+        _copy_tree(src, dst, lg)
+    else:
+        raise ValueError(f"Unknown publish artifact kind: {kind}")
+
+
+def _copy_and_verify_publish_artifacts(
+    artifacts: list[tuple[str, str, str]],
+    lg: logging.LoggerAdapter,
+    max_attempts: int = PUBLISH_MAX_ATTEMPTS,
+    retry_delay_seconds: int = PUBLISH_RETRY_DELAY_SECONDS,
+) -> None:
+    last_error = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            lg.info("Publish copy/verify attempt %d/%d.", attempt, max_attempts)
+            for kind, src, dst in artifacts:
+                _copy_publish_artifact(kind, src, dst, lg)
+            _verify_publish_artifacts(artifacts, lg)
+            return
+        except Exception as e:
+            last_error = e
+            if attempt >= max_attempts:
+                lg.error(
+                    "FAILED publish verification after %d attempt(s): %s",
+                    max_attempts,
+                    e,
+                )
+                raise
+
+            lg.warning(
+                "Publish copy/verify attempt %d/%d failed: %s. Retrying in %d s.",
+                attempt,
+                max_attempts,
+                e,
+                retry_delay_seconds,
+            )
+            time.sleep(retry_delay_seconds)
+
+    if last_error is not None:
+        raise last_error
 
 
 def _snapshot_shell_logs(
@@ -2702,72 +2840,55 @@ def main(
         )
         raise
 
-    # 1) process_info/
-    try:
-        _copy_tree(
+    src_out = f"{staged_output_base}.{output_format}"
+    dst_out = os.path.join(out_root_and_dir, f"{output_name}.{output_format}")
+    publish_artifacts = [
+        (
+            "tree",
             os.path.join(base_dir, "process_info"),
             os.path.join(out_root_and_dir, "process_info"),
-            publish_logger,
-        )
-    except Exception as e:
-        publish_logger.error("FAILED to copy process_info/: %s", e)
-        raise
-
-    # 2) process.yml and process.yaml
-    try:
-        _copy_file(
+        ),
+        (
+            "file",
             os.path.join(base_dir, "process.yml"),
             os.path.join(out_root_and_dir, "process.yml"),
-            publish_logger,
-        )
-        if os.path.exists(os.path.join(base_dir, "process.yaml")):
-            _copy_file(
+        ),
+        (
+            "tree" if output_format == "hats" else "file",
+            src_out,
+            dst_out,
+        ),
+    ]
+    if os.path.exists(os.path.join(base_dir, "process.yaml")):
+        publish_artifacts.append(
+            (
+                "file",
                 os.path.join(base_dir, "process.yaml"),
                 os.path.join(out_root_and_dir, "process.yaml"),
-                publish_logger,
             )
-    except Exception as e:
-        publish_logger.error("FAILED to copy process.yml/.yaml: %s", e)
-        raise
-
-    # 3) config.yaml
-    try:
-        if os.path.exists(os.path.join(base_dir, "config.yaml")):
-            _copy_file(
+        )
+    if os.path.exists(os.path.join(base_dir, "config.yaml")):
+        publish_artifacts.append(
+            (
+                "file",
                 os.path.join(base_dir, "config.yaml"),
                 os.path.join(out_root_and_dir, "config.yaml"),
-                publish_logger,
             )
-    except Exception as e:
-        publish_logger.error("FAILED to copy config.yaml: %s", e)
-        raise
-
-    # 4) flags_translation.yaml
-    try:
-        if os.path.exists(path_to_translation_file):
-            _copy_file(
+        )
+    if os.path.exists(path_to_translation_file):
+        publish_artifacts.append(
+            (
+                "file",
                 path_to_translation_file,
                 os.path.join(out_root_and_dir, "flags_translation.yaml"),
-                publish_logger,
             )
-    except Exception as e:
-        publish_logger.error("FAILED to copy flags_translation.yaml: %s", e)
-        raise
+        )
 
-    # 5) final output
-    try:
-        src_out = f"{staged_output_base}.{output_format}"
-        dst_out = os.path.join(out_root_and_dir, f"{output_name}.{output_format}")
-        publish_logger.info("Copying final output: %s -> %s", src_out, dst_out)
-        if output_format == "hats":
-            _copy_tree(src_out, dst_out, publish_logger)
-        else:
-            _copy_file(src_out, dst_out, publish_logger)
-    except Exception as e:
-        publish_logger.error("FAILED to copy final output to publish dir: %s", e)
-        raise
+    _copy_and_verify_publish_artifacts(publish_artifacts, publish_logger)
 
-    publish_logger.info("END publish: artifacts copied to %s", out_root_and_dir)
+    publish_logger.info(
+        "END publish: artifacts copied and verified at %s", out_root_and_dir
+    )
 
     if delete_temp_files:
         try:

--- a/scripts/crd-run.py
+++ b/scripts/crd-run.py
@@ -114,6 +114,12 @@ TRANSLATION_FALLBACK_DEFAULTS = {
 
 PUBLISH_MAX_ATTEMPTS = 3
 PUBLISH_RETRY_DELAY_SECONDS = 5
+PUBLISH_INTEGRITY_CHECK_BASIC = "basic"
+PUBLISH_INTEGRITY_CHECK_CHECKSUM = "checksum"
+PUBLISH_INTEGRITY_CHECK_OPTIONS = {
+    PUBLISH_INTEGRITY_CHECK_BASIC,
+    PUBLISH_INTEGRITY_CHECK_CHECKSUM,
+}
 
 
 def _build_runtime_param_config(param_config: dict | None) -> dict:
@@ -228,19 +234,31 @@ def _build_runtime_param_config(param_config: dict | None) -> dict:
             "homogenized_columns",
             "insert_DP1_footprint_flag",
             "insert_rubin_footprint_flag",
+            "publish_integrity_check",
         }
     )
     if unknown_output:
         raise ValueError(f"param.output has unknown option(s): {unknown_output}")
+    publish_integrity_check = str(
+        output.get("publish_integrity_check", PUBLISH_INTEGRITY_CHECK_BASIC)
+        or PUBLISH_INTEGRITY_CHECK_BASIC
+    ).strip().lower()
+    if publish_integrity_check not in PUBLISH_INTEGRITY_CHECK_OPTIONS:
+        raise ValueError(
+            "param.output.publish_integrity_check must be one of "
+            f"{sorted(PUBLISH_INTEGRITY_CHECK_OPTIONS)}"
+        )
     output_aliases = {
         "extra_columns": "extra_columns",
         "homogenized_columns": "output_homogenized_columns",
         "insert_DP1_footprint_flag": "insert_DP1_footprint_flag",
         "insert_rubin_footprint_flag": "insert_rubin_footprint_flag",
+        "publish_integrity_check": "publish_integrity_check",
     }
     for source, target in output_aliases.items():
         if source in output:
             normalized[target] = output[source]
+    normalized["publish_integrity_check"] = publish_integrity_check
 
     return normalized
 
@@ -808,7 +826,7 @@ def _sha256_file(path: str) -> str:
     return digest.hexdigest()
 
 
-def _verify_copied_file(src: str, dst: str) -> None:
+def _verify_copied_file(src: str, dst: str, integrity_check: str) -> None:
     if not os.path.isfile(src):
         raise FileNotFoundError(f"source file is missing: {src}")
     if not os.path.isfile(dst):
@@ -822,6 +840,22 @@ def _verify_copied_file(src: str, dst: str) -> None:
             f"{src} ({src_size} bytes) != {dst} ({dst_size} bytes)"
         )
 
+    src_mtime = os.path.getmtime(src)
+    dst_mtime = os.path.getmtime(dst)
+    if abs(src_mtime - dst_mtime) > 1.0:
+        raise RuntimeError(
+            "copied file mtime mismatch: "
+            f"{src} ({src_mtime}) != {dst} ({dst_mtime})"
+        )
+
+    if integrity_check == PUBLISH_INTEGRITY_CHECK_BASIC:
+        return
+    if integrity_check != PUBLISH_INTEGRITY_CHECK_CHECKSUM:
+        raise ValueError(
+            "publish_integrity_check must be one of "
+            f"{sorted(PUBLISH_INTEGRITY_CHECK_OPTIONS)}"
+        )
+
     src_hash = _sha256_file(src)
     dst_hash = _sha256_file(dst)
     if src_hash != dst_hash:
@@ -830,7 +864,9 @@ def _verify_copied_file(src: str, dst: str) -> None:
         )
 
 
-def _verify_copied_tree(src_dir: str, dst_dir: str) -> tuple[int, int]:
+def _verify_copied_tree(
+    src_dir: str, dst_dir: str, integrity_check: str
+) -> tuple[int, int]:
     if not os.path.isdir(src_dir):
         raise FileNotFoundError(f"source directory is missing: {src_dir}")
     if not os.path.isdir(dst_dir):
@@ -855,7 +891,7 @@ def _verify_copied_tree(src_dir: str, dst_dir: str) -> tuple[int, int]:
         for filename in files:
             src_file = os.path.join(root, filename)
             dst_file = os.path.join(dst_root, filename)
-            _verify_copied_file(src_file, dst_file)
+            _verify_copied_file(src_file, dst_file, integrity_check)
             n_files += 1
 
     return n_dirs, n_files
@@ -864,23 +900,25 @@ def _verify_copied_tree(src_dir: str, dst_dir: str) -> tuple[int, int]:
 def _verify_publish_artifacts(
     artifacts: list[tuple[str, str, str]],
     lg: logging.LoggerAdapter,
+    integrity_check: str = PUBLISH_INTEGRITY_CHECK_BASIC,
 ) -> None:
     """Verify published artifacts against staged sources."""
     total_files = 0
     total_dirs = 0
     for kind, src, dst in artifacts:
         if kind == "file":
-            _verify_copied_file(src, dst)
+            _verify_copied_file(src, dst, integrity_check)
             total_files += 1
         elif kind == "tree":
-            n_dirs, n_files = _verify_copied_tree(src, dst)
+            n_dirs, n_files = _verify_copied_tree(src, dst, integrity_check)
             total_dirs += n_dirs
             total_files += n_files
         else:
             raise ValueError(f"Unknown publish artifact kind: {kind}")
 
     lg.info(
-        "Publish verification passed: %d file(s), %d directories verified.",
+        "Publish verification passed (%s): %d file(s), %d directories verified.",
+        integrity_check,
         total_files,
         total_dirs,
     )
@@ -902,6 +940,7 @@ def _copy_and_verify_publish_artifacts(
     lg: logging.LoggerAdapter,
     max_attempts: int = PUBLISH_MAX_ATTEMPTS,
     retry_delay_seconds: int = PUBLISH_RETRY_DELAY_SECONDS,
+    integrity_check: str = PUBLISH_INTEGRITY_CHECK_BASIC,
 ) -> None:
     last_error = None
     for attempt in range(1, max_attempts + 1):
@@ -909,7 +948,7 @@ def _copy_and_verify_publish_artifacts(
             lg.info("Publish copy/verify attempt %d/%d.", attempt, max_attempts)
             for kind, src, dst in artifacts:
                 _copy_publish_artifact(kind, src, dst, lg)
-            _verify_publish_artifacts(artifacts, lg)
+            _verify_publish_artifacts(artifacts, lg, integrity_check)
             return
         except Exception as e:
             last_error = e
@@ -2884,7 +2923,13 @@ def main(
             )
         )
 
-    _copy_and_verify_publish_artifacts(publish_artifacts, publish_logger)
+    _copy_and_verify_publish_artifacts(
+        publish_artifacts,
+        publish_logger,
+        integrity_check=param_config.get(
+            "publish_integrity_check", PUBLISH_INTEGRITY_CHECK_BASIC
+        ),
+    )
 
     publish_logger.info(
         "END publish: artifacts copied and verified at %s", out_root_and_dir

--- a/scripts/crd-run.py
+++ b/scripts/crd-run.py
@@ -840,14 +840,6 @@ def _verify_copied_file(src: str, dst: str, integrity_check: str) -> None:
             f"{src} ({src_size} bytes) != {dst} ({dst_size} bytes)"
         )
 
-    src_mtime = os.path.getmtime(src)
-    dst_mtime = os.path.getmtime(dst)
-    if abs(src_mtime - dst_mtime) > 1.0:
-        raise RuntimeError(
-            "copied file mtime mismatch: "
-            f"{src} ({src_mtime}) != {dst} ({dst_mtime})"
-        )
-
     if integrity_check == PUBLISH_INTEGRITY_CHECK_BASIC:
         return
     if integrity_check != PUBLISH_INTEGRITY_CHECK_CHECKSUM:

--- a/scripts/crd-run.py
+++ b/scripts/crd-run.py
@@ -112,33 +112,67 @@ TRANSLATION_FALLBACK_DEFAULTS = {
 }
 
 
-def _normalize_param_config(param_config: dict | None) -> dict:
-    """Normalize supported external param layouts to the internal flat layout."""
+def _build_runtime_param_config(param_config: dict | None) -> dict:
+    """Build the internal runtime param mapping from the canonical config layout."""
     if param_config is None:
         return {}
     if not isinstance(param_config, dict):
         raise TypeError("param must be a mapping")
 
+    allowed_sections = {"run", "filters", "preparation", "diagnostics", "output"}
+    unknown_sections = sorted(set(param_config) - allowed_sections)
+    if unknown_sections:
+        raise ValueError(f"param has unknown section(s): {unknown_sections}")
+
     normalized = dict(param_config)
 
-    run = normalized.get("run") or {}
+    run = normalized.get("run")
     if not isinstance(run, dict):
         raise TypeError("param.run must be a mapping")
+    unknown_run = sorted(
+        set(run) - {"combine_type", "tie_treatment_option", "flags_translation_file"}
+    )
+    if unknown_run:
+        raise ValueError(f"param.run has unknown option(s): {unknown_run}")
     for key in ("combine_type", "tie_treatment_option", "flags_translation_file"):
         if key in run:
             normalized[key] = run[key]
 
-    filters = normalized.get("filters") or {}
+    filters = normalized.get("filters")
     if not isinstance(filters, dict):
         raise TypeError("param.filters must be a mapping")
+    unknown_filters = sorted(
+        set(filters)
+        - {
+            "z_flag_homogenized_value_to_cut",
+            "instrument_type_homogenized",
+            "object_type_homogenized",
+        }
+    )
+    if unknown_filters:
+        raise ValueError(f"param.filters has unknown option(s): {unknown_filters}")
     if "z_flag_homogenized_value_to_cut" in filters:
         normalized["z_flag_homogenized_value_to_cut"] = filters[
             "z_flag_homogenized_value_to_cut"
         ]
 
-    instrument = filters.get("instrument_type_homogenized") or {}
+    instrument = filters.get("instrument_type_homogenized")
     if not isinstance(instrument, dict):
         raise TypeError("param.filters.instrument_type_homogenized must be a mapping")
+    unknown_instrument = sorted(
+        set(instrument)
+        - {
+            "include_spectroscopic",
+            "include_grism",
+            "include_photometric",
+            "include_unclassified",
+        }
+    )
+    if unknown_instrument:
+        raise ValueError(
+            "param.filters.instrument_type_homogenized has unknown option(s): "
+            f"{unknown_instrument}"
+        )
     instrument_aliases = {
         "include_spectroscopic": "include_spectroscopic_ith",
         "include_grism": "include_grism_ith",
@@ -149,9 +183,25 @@ def _normalize_param_config(param_config: dict | None) -> dict:
         if source in instrument:
             normalized[target] = instrument[source]
 
-    object_type = filters.get("object_type_homogenized") or {}
+    object_type = filters.get("object_type_homogenized")
     if not isinstance(object_type, dict):
         raise TypeError("param.filters.object_type_homogenized must be a mapping")
+    unknown_object_type = sorted(
+        set(object_type)
+        - {
+            "include_unclassified",
+            "include_galaxy",
+            "include_star",
+            "include_agn",
+            "include_qso",
+            "include_galactic",
+        }
+    )
+    if unknown_object_type:
+        raise ValueError(
+            "param.filters.object_type_homogenized has unknown option(s): "
+            f"{unknown_object_type}"
+        )
     object_aliases = {
         "include_unclassified": "include_unclassified_oth",
         "include_galaxy": "include_galaxy_oth",
@@ -164,9 +214,20 @@ def _normalize_param_config(param_config: dict | None) -> dict:
         if source in object_type:
             normalized[target] = object_type[source]
 
-    output = normalized.get("output") or {}
+    output = normalized.get("output")
     if not isinstance(output, dict):
         raise TypeError("param.output must be a mapping")
+    unknown_output = sorted(
+        set(output)
+        - {
+            "extra_columns",
+            "homogenized_columns",
+            "insert_DP1_footprint_flag",
+            "insert_rubin_footprint_flag",
+        }
+    )
+    if unknown_output:
+        raise ValueError(f"param.output has unknown option(s): {unknown_output}")
     output_aliases = {
         "extra_columns": "extra_columns",
         "homogenized_columns": "output_homogenized_columns",
@@ -209,18 +270,13 @@ def _merge_param_diagnostics(
     if not isinstance(diagnostics, dict):
         raise TypeError("param.diagnostics must be a mapping")
 
-    legacy_diagnostics_keys = {"expr_column_schema"}
-    unknown = sorted(set(diagnostics) - set(DIAGNOSTICS_DEFAULTS) - legacy_diagnostics_keys)
+    unknown = sorted(set(diagnostics) - set(DIAGNOSTICS_DEFAULTS))
     if unknown:
         raise ValueError(f"param.diagnostics has unknown option(s): {unknown}")
 
     for key, default in DIAGNOSTICS_DEFAULTS.items():
         merged[key] = diagnostics.get(key, merged.get(key, default))
-    merged["expr_column_schema"] = (
-        merged.get("expr_column_schema")
-        or diagnostics.get("expr_column_schema")
-        or {}
-    )
+    merged["expr_column_schema"] = merged.get("expr_column_schema") or {}
 
     for key in (
         "tie_invariant_diagnostics_enabled",
@@ -776,7 +832,7 @@ def main(
 
     # --- Load config ---
     config = load_yml(config_path)
-    param_config = _normalize_param_config(config.get("param", {}))
+    param_config = _build_runtime_param_config(config.get("param", {}))
     if base_dir_override is None:
         raise ValueError("You must specify --base_dir via the command line.")
     base_dir = base_dir_override

--- a/scripts/crd-run.py
+++ b/scripts/crd-run.py
@@ -47,6 +47,7 @@ from deduplication import (
     filter_dask_by_tie_treatment,
     filter_pandas_by_tie_treatment,
     run_dedup_with_lsdb_map_partitions,
+    validate_instrument_type_inclusion,
     validate_object_type_inclusion,
     validate_spatial_safety,
 )
@@ -54,6 +55,7 @@ from executor import get_executor
 from product_handle import save_dataframe
 from resource_usage import ResourceUsageMonitor
 from specz import (
+    HOMOGENIZED_COLUMNS,
     build_runtime_schema_hints,
     prepare_catalog,
     validate_combine_configuration,
@@ -76,6 +78,199 @@ __all__ = ["main"]
 
 _resource_usage_monitor: ResourceUsageMonitor | None = None
 _worker_floor_monitor: WorkerFloorMonitor | None = None
+
+DIAGNOSTICS_DEFAULTS = {
+    "tie_invariant_diagnostics_enabled": True,
+    "tie_invariant_diagnostics_detailed_enabled": False,
+    "tie_invariant_diagnostics_sample_size": 10,
+    "tie_invariant_diagnostics_max_rows": 100,
+    "label_merge_diagnostics_enabled": True,
+    "crossmatch_geometry_diagnostics_enabled": False,
+    "representative_radius_diagnostics_enabled": False,
+    "dedup_edge_diagnostics_enabled": False,
+    "save_expr_columns": False,
+}
+
+PREPARATION_DEFAULTS = {
+    "repartition_prepared_catalogs": False,
+    "prepared_partition_size": "256MB",
+}
+
+TRANSLATION_FALLBACK_DEFAULTS = {
+    "crossmatch_radius_arcsec": 0.5,
+    "max_representative_radius_arcsec": None,
+    "margin_threshold_arcsec": 5.0,
+    "margin_warning_fraction": 0.8,
+    "crossmatch_n_neighbors": 160,
+    "crossmatch_saturation_enabled": False,
+    "crossmatch_saturation_warn_fraction": 0.01,
+    "crossmatch_saturation_fail_fraction": None,
+    "delta_z_threshold": 0.0,
+    "validate_global_graph_edges": False,
+    "validate_global_tie_invariants": True,
+    "validate_crd_id_uniqueness": True,
+}
+
+
+def _normalize_param_config(param_config: dict | None) -> dict:
+    """Normalize supported external param layouts to the internal flat layout."""
+    if param_config is None:
+        return {}
+    if not isinstance(param_config, dict):
+        raise TypeError("param must be a mapping")
+
+    normalized = dict(param_config)
+
+    run = normalized.get("run") or {}
+    if not isinstance(run, dict):
+        raise TypeError("param.run must be a mapping")
+    for key in ("combine_type", "tie_treatment_option", "flags_translation_file"):
+        if key in run:
+            normalized[key] = run[key]
+
+    filters = normalized.get("filters") or {}
+    if not isinstance(filters, dict):
+        raise TypeError("param.filters must be a mapping")
+    if "z_flag_homogenized_value_to_cut" in filters:
+        normalized["z_flag_homogenized_value_to_cut"] = filters[
+            "z_flag_homogenized_value_to_cut"
+        ]
+
+    instrument = filters.get("instrument_type_homogenized") or {}
+    if not isinstance(instrument, dict):
+        raise TypeError("param.filters.instrument_type_homogenized must be a mapping")
+    instrument_aliases = {
+        "include_spectroscopic": "include_spectroscopic_ith",
+        "include_grism": "include_grism_ith",
+        "include_photometric": "include_photometric_ith",
+        "include_unclassified": "include_unclassified_ith",
+    }
+    for source, target in instrument_aliases.items():
+        if source in instrument:
+            normalized[target] = instrument[source]
+
+    object_type = filters.get("object_type_homogenized") or {}
+    if not isinstance(object_type, dict):
+        raise TypeError("param.filters.object_type_homogenized must be a mapping")
+    object_aliases = {
+        "include_unclassified": "include_unclassified_oth",
+        "include_galaxy": "include_galaxy_oth",
+        "include_star": "include_star_oth",
+        "include_agn": "include_agn_oth",
+        "include_qso": "include_qso_oth",
+        "include_galactic": "include_galactic_oth",
+    }
+    for source, target in object_aliases.items():
+        if source in object_type:
+            normalized[target] = object_type[source]
+
+    output = normalized.get("output") or {}
+    if not isinstance(output, dict):
+        raise TypeError("param.output must be a mapping")
+    output_aliases = {
+        "extra_columns": "extra_columns",
+        "homogenized_columns": "output_homogenized_columns",
+        "insert_DP1_footprint_flag": "insert_DP1_footprint_flag",
+        "insert_rubin_footprint_flag": "insert_rubin_footprint_flag",
+    }
+    for source, target in output_aliases.items():
+        if source in output:
+            normalized[target] = output[source]
+
+    return normalized
+
+
+def _log_translation_fallbacks(
+    translation_config: dict,
+    logger: logging.LoggerAdapter | logging.Logger,
+) -> None:
+    """Warn when optional scientific settings rely on internal defaults."""
+    missing = {
+        key: default
+        for key, default in TRANSLATION_FALLBACK_DEFAULTS.items()
+        if key not in translation_config
+    }
+    if not missing:
+        return
+    logger.warning(
+        "flags_translation.yaml is missing optional scientific setting(s); "
+        "using internal fallback defaults: %s",
+        missing,
+    )
+
+
+def _merge_param_diagnostics(
+    translation_config: dict,
+    param_config: dict,
+) -> dict:
+    """Overlay operational diagnostics from param.diagnostics onto runtime config."""
+    merged = dict(translation_config or {})
+    diagnostics = param_config.get("diagnostics") or {}
+    if not isinstance(diagnostics, dict):
+        raise TypeError("param.diagnostics must be a mapping")
+
+    legacy_diagnostics_keys = {"expr_column_schema"}
+    unknown = sorted(set(diagnostics) - set(DIAGNOSTICS_DEFAULTS) - legacy_diagnostics_keys)
+    if unknown:
+        raise ValueError(f"param.diagnostics has unknown option(s): {unknown}")
+
+    for key, default in DIAGNOSTICS_DEFAULTS.items():
+        merged[key] = diagnostics.get(key, merged.get(key, default))
+    merged["expr_column_schema"] = (
+        merged.get("expr_column_schema")
+        or diagnostics.get("expr_column_schema")
+        or {}
+    )
+
+    for key in (
+        "tie_invariant_diagnostics_enabled",
+        "tie_invariant_diagnostics_detailed_enabled",
+        "label_merge_diagnostics_enabled",
+        "crossmatch_geometry_diagnostics_enabled",
+        "representative_radius_diagnostics_enabled",
+        "dedup_edge_diagnostics_enabled",
+        "save_expr_columns",
+    ):
+        if not isinstance(merged[key], bool):
+            raise TypeError(f"param.diagnostics.{key} must be a boolean")
+
+    for key in (
+        "tie_invariant_diagnostics_sample_size",
+        "tie_invariant_diagnostics_max_rows",
+    ):
+        value = merged[key]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError(f"param.diagnostics.{key} must be a positive integer")
+
+    if not isinstance(merged["expr_column_schema"], dict):
+        raise TypeError("flags_translation.expr_column_schema must be a mapping")
+
+    return merged
+
+
+def _merge_param_preparation(
+    translation_config: dict,
+    param_config: dict,
+) -> dict:
+    """Overlay operational preparation settings from param.preparation."""
+    merged = dict(translation_config or {})
+    preparation = param_config.get("preparation") or {}
+    if not isinstance(preparation, dict):
+        raise TypeError("param.preparation must be a mapping")
+
+    unknown = sorted(set(preparation) - set(PREPARATION_DEFAULTS))
+    if unknown:
+        raise ValueError(f"param.preparation has unknown option(s): {unknown}")
+
+    for key, default in PREPARATION_DEFAULTS.items():
+        merged[key] = preparation.get(key, merged.get(key, default))
+
+    if not isinstance(merged["repartition_prepared_catalogs"], bool):
+        raise TypeError("param.preparation.repartition_prepared_catalogs must be a boolean")
+    if not isinstance(merged["prepared_partition_size"], str):
+        raise TypeError("param.preparation.prepared_partition_size must be a string")
+
+    return merged
 
 
 # -----------------------
@@ -581,7 +776,7 @@ def main(
 
     # --- Load config ---
     config = load_yml(config_path)
-    param_config = config.get("param", {})
+    param_config = _normalize_param_config(config.get("param", {}))
     if base_dir_override is None:
         raise ValueError("You must specify --base_dir via the command line.")
     base_dir = base_dir_override
@@ -651,7 +846,7 @@ def main(
             )
 
     log_init.info("START init: pipeline bootstrap")
-    cut_value = param_config.get("z_flag_homogenized_value_to_cut")
+    cut_value = param_config.get("z_flag_homogenized_value_to_cut", 0)
     try:
         cut_value_numeric = float(cut_value) if cut_value is not None else None
     except (TypeError, ValueError):
@@ -732,6 +927,15 @@ def main(
     try:
         translation_config = load_yml(path_to_translation_file)
         validate_translation_config(translation_config)
+        _log_translation_fallbacks(translation_config, log_init)
+        translation_config = _merge_param_diagnostics(
+            translation_config,
+            param_config,
+        )
+        translation_config = _merge_param_preparation(
+            translation_config,
+            param_config,
+        )
     except Exception as e:
         log_init.error("Failed to parse flags_translation_file: %s", e, exc_info=True)
         raise
@@ -796,37 +1000,56 @@ def main(
     combine_mode, validated_priorities = validate_combine_configuration(
         param_config.get("combine_type", "concatenate_and_mark_duplicates"),
         translation_config.get("tiebreaking_priority", []),
-        param_config.get("z_flag_homogenized_value_to_cut"),
+        param_config.get("z_flag_homogenized_value_to_cut", 0),
         log_init,
     )
     translation_config["tiebreaking_priority"] = validated_priorities
-    object_type_inclusion = validate_object_type_inclusion(
+    instrument_type_inclusion = validate_instrument_type_inclusion(
         {
             key: param_config[key]
             for key in (
-                "include_unclassified",
-                "include_galaxy",
-                "include_star",
-                "include_agn",
-                "include_qso",
-                "include_galactic",
+                "include_spectroscopic_ith",
+                "include_grism_ith",
+                "include_photometric_ith",
+                "include_unclassified_ith",
             )
             if key in param_config
         }
     )
-    log_init.info("Object-type graph inclusion: %s", object_type_inclusion)
-    if (
-        cut_value_numeric in {1.0, 2.0, 3.0, 4.0}
-        and (
-            object_type_inclusion["include_star"]
-            or object_type_inclusion["include_galactic"]
+    object_type_inclusion = validate_object_type_inclusion(
+        {
+            key: param_config[key]
+            for key in (
+                "include_unclassified_oth",
+                "include_galaxy_oth",
+                "include_star_oth",
+                "include_agn_oth",
+                "include_qso_oth",
+                "include_galactic_oth",
+            )
+            if key in param_config
+        }
+    )
+    log_init.info("Instrument-type input filter inclusion: %s", instrument_type_inclusion)
+    log_init.info("Object-type input filter inclusion: %s", object_type_inclusion)
+    required_homogenized_columns: dict[str, list[str]] = {
+        column: ["tiebreaking_priority"]
+        for column in HOMOGENIZED_COLUMNS
+        if column in set(validated_priorities)
+    }
+    if cut_value_numeric in {1.0, 2.0, 3.0, 4.0}:
+        required_homogenized_columns.setdefault("z_flag_homogenized", []).append(
+            "z_flag_homogenized_value_to_cut"
         )
-    ):
-        log_init.warning(
-            "An active z_flag_homogenized cut removes star/galactic rows whose "
-            "quality is null before graph inclusion. Their internal 0.5 ranking "
-            "fallback applies only to rows that survive this cut."
-        )
+    if not all(instrument_type_inclusion.values()):
+        required_homogenized_columns.setdefault(
+            "instrument_type_homogenized", []
+        ).append("instrument_type_filter")
+    if not all(object_type_inclusion.values()):
+        required_homogenized_columns.setdefault(
+            "object_type_homogenized", []
+        ).append("object_type_filter")
+    log_init.info("Required homogenized columns: %s", required_homogenized_columns)
     translation_config["runtime_schema_hints"] = build_runtime_schema_hints(
         param_config, translation_config
     )
@@ -1067,6 +1290,61 @@ def main(
                 len(results) - len(empty_results),
             )
 
+        homogenized_metadata = []
+        for r in results:
+            metadata_path = os.path.join(
+                temp_dir, f"prepared_{r[3]}.homogenized.json"
+            )
+            try:
+                with open(metadata_path, encoding="utf-8") as fp:
+                    homogenized_metadata.append(json.load(fp))
+            except FileNotFoundError:
+                log_prep.warning(
+                    "Missing homogenized metadata for catalog %s at %s. "
+                    "Required-column global validation will count it as empty.",
+                    r[3],
+                    metadata_path,
+                )
+                homogenized_metadata.append(
+                    {
+                        "product": r[3],
+                        "homogenized_non_null_counts": {},
+                    }
+                )
+            except Exception as e:
+                raise RuntimeError(
+                    f"Could not read homogenized metadata for catalog {r[3]} "
+                    f"at {metadata_path}: {e}"
+                ) from e
+
+        for column, reasons in required_homogenized_columns.items():
+            per_catalog_counts = {
+                str(meta.get("product") or "unknown"): int(
+                    (meta.get("homogenized_non_null_counts") or {}).get(column, 0)
+                )
+                for meta in homogenized_metadata
+            }
+            total_non_null = sum(per_catalog_counts.values())
+            if total_non_null == 0:
+                raise RuntimeError(
+                    f"All input catalogs have no valid values for required "
+                    f"homogenized column '{column}'. Required because: {reasons}. "
+                    f"Per-catalog non-null counts: {per_catalog_counts}. "
+                    "Check input column mappings and flags_translation.yaml."
+                )
+            empty_catalogs_for_column = [
+                name for name, count in per_catalog_counts.items() if count == 0
+            ]
+            if empty_catalogs_for_column:
+                log_prep.warning(
+                    "Required homogenized column %s has no non-null values in "
+                    "some input catalogs: %s; continuing because other catalogs "
+                    "provide valid values. Reasons=%s",
+                    column,
+                    empty_catalogs_for_column,
+                    reasons,
+                )
+
         prepared_info = [
             {
                 "collection_path": r[0],
@@ -1081,13 +1359,14 @@ def main(
 
         if not prepared_info:
             if len(empty_results) == len(results) and all(
-                r[4] == "empty_after_cut" for r in empty_results
+                r[4] in {"empty_after_cut", "empty_after_filter"}
+                for r in empty_results
             ):
-                names = ", ".join(r[3] for r in empty_results)
+                names = ", ".join(f"{r[3]} ({r[4]})" for r in empty_results)
                 raise RuntimeError(
-                    "All input catalogs became empty after applying the "
-                    "z_flag_homogenized cut; no non-empty catalogs remain for "
-                    f"downstream processing. Empty catalogs: {names}."
+                    "All input catalogs became empty after applying preparation "
+                    "filters; no non-empty catalogs remain for downstream "
+                    f"processing. Empty catalogs: {names}."
                 )
             raise RuntimeError(
                 "All input catalogs were excluded during preparation; no non-empty "

--- a/tests/test_crd_ids.py
+++ b/tests/test_crd_ids.py
@@ -90,13 +90,40 @@ def test_generate_crd_ids_do_not_depend_on_row_order_or_partitions():
     assert first_map == second_map
 
 
-def test_generate_crd_ids_duplicate_ra_dec_z_collide_for_validation():
+def test_generate_crd_ids_optional_canonical_columns_disambiguate_coordinates():
     frame = dd.from_pandas(
         pd.DataFrame(
             {
+                "id": ["first", "second"],
                 "ra": [10.0, 10.0],
                 "dec": [-10.0, -10.0],
                 "z": [0.1, 0.1],
+                "z_flag": [1.0, 2.0],
+                "survey": ["same", "same"],
+            }
+        ),
+        npartitions=2,
+        sort=False,
+    )
+
+    result = _generate_crd_ids(frame, "314_example", "/tmp").compute()
+
+    assert result["CRD_ID"].is_unique
+
+
+def test_generate_crd_ids_collide_when_all_available_canonical_values_match():
+    frame = dd.from_pandas(
+        pd.DataFrame(
+            {
+                "id": ["same", "same"],
+                "ra": [10.0, 10.0],
+                "dec": [-10.0, -10.0],
+                "z": [0.1, 0.1],
+                "z_flag": [1.0, 1.0],
+                "z_err": [0.01, 0.01],
+                "survey": ["same", "same"],
+                "source": ["same", "same"],
+                "instrument_type": ["same", "same"],
             }
         ),
         npartitions=2,

--- a/tests/test_crd_ids.py
+++ b/tests/test_crd_ids.py
@@ -18,13 +18,21 @@ from specz import _generate_crd_ids, _validate_unique_crd_ids  # noqa: E402
 
 def test_generate_crd_ids_are_unique_across_partitions():
     frame = dd.from_pandas(
-        pd.DataFrame({"value": range(17)}), npartitions=4, sort=False
+        pd.DataFrame(
+            {
+                "ra": [float(i) for i in range(17)],
+                "dec": [float(-i) for i in range(17)],
+                "z": [float(i) / 10.0 for i in range(17)],
+            }
+        ),
+        npartitions=4,
+        sort=False,
     )
 
     result = _generate_crd_ids(frame, "314_example", "/tmp").compute()
 
     assert result["CRD_ID"].is_unique
-    assert set(result["CRD_ID"]) == {f"CRD314_{i}" for i in range(1, 18)}
+    assert result["CRD_ID"].str.match(r"^CRD314_[0-9a-f]{16}$").all()
 
 
 def test_validate_unique_crd_ids_rejects_collisions():
@@ -40,12 +48,62 @@ def test_validate_unique_crd_ids_rejects_collisions():
 
 def test_generate_crd_ids_is_deterministic_for_same_partitioned_input():
     frame = dd.from_pandas(
-        pd.DataFrame({"value": range(12)}), npartitions=3, sort=False
+        pd.DataFrame(
+            {
+                "ra": [float(i) for i in range(12)],
+                "dec": [float(i + 1) for i in range(12)],
+                "z": [float(i + 2) for i in range(12)],
+            }
+        ),
+        npartitions=3,
+        sort=False,
     )
 
     first = _generate_crd_ids(frame, "314_example", "/tmp").compute()
     second = _generate_crd_ids(frame, "314_example", "/tmp").compute()
 
-    assert first[["value", "CRD_ID"]].to_dict("records") == second[
-        ["value", "CRD_ID"]
+    assert first[["ra", "dec", "z", "CRD_ID"]].to_dict("records") == second[
+        ["ra", "dec", "z", "CRD_ID"]
     ].to_dict("records")
+
+
+def test_generate_crd_ids_do_not_depend_on_row_order_or_partitions():
+    pdf = pd.DataFrame(
+        {
+            "id": ["duplicate", "duplicate", None, "ignored"],
+            "ra": [10.0, 20.0, 30.0, 40.0],
+            "dec": [-10.0, -20.0, -30.0, -40.0],
+            "z": [0.1, 0.2, 0.3, 0.4],
+        }
+    )
+    forward = dd.from_pandas(pdf, npartitions=2, sort=False)
+    reverse = dd.from_pandas(
+        pdf.iloc[::-1].reset_index(drop=True), npartitions=3, sort=False
+    )
+
+    first = _generate_crd_ids(forward, "314_example", "/tmp").compute()
+    second = _generate_crd_ids(reverse, "314_example", "/tmp").compute()
+
+    key = ["ra", "dec", "z"]
+    first_map = first.set_index(key)["CRD_ID"].to_dict()
+    second_map = second.set_index(key)["CRD_ID"].to_dict()
+    assert first_map == second_map
+
+
+def test_generate_crd_ids_duplicate_ra_dec_z_collide_for_validation():
+    frame = dd.from_pandas(
+        pd.DataFrame(
+            {
+                "ra": [10.0, 10.0],
+                "dec": [-10.0, -10.0],
+                "z": [0.1, 0.1],
+            }
+        ),
+        npartitions=2,
+        sort=False,
+    )
+
+    result = _generate_crd_ids(frame, "314_example", "/tmp")
+
+    with pytest.raises(RuntimeError, match="non-unique CRD_ID"):
+        _validate_unique_crd_ids(result, "314_example", logging.getLogger(__name__))

--- a/tests/test_crd_ids.py
+++ b/tests/test_crd_ids.py
@@ -111,7 +111,7 @@ def test_generate_crd_ids_optional_canonical_columns_disambiguate_coordinates():
     assert result["CRD_ID"].is_unique
 
 
-def test_generate_crd_ids_collide_when_all_available_canonical_values_match():
+def test_generate_crd_ids_collide_when_all_available_canonical_values_match(caplog):
     frame = dd.from_pandas(
         pd.DataFrame(
             {
@@ -132,5 +132,11 @@ def test_generate_crd_ids_collide_when_all_available_canonical_values_match():
 
     result = _generate_crd_ids(frame, "314_example", "/tmp")
 
+    caplog.set_level(logging.ERROR)
     with pytest.raises(RuntimeError, match="non-unique CRD_ID"):
         _validate_unique_crd_ids(result, "314_example", logging.getLogger(__name__))
+
+    assert "CRD_ID collision diagnostics" in caplog.text
+    assert "duplicate_rows=1" in caplog.text
+    assert "sample_groups=" in caplog.text
+    assert "sample_rows=" in caplog.text

--- a/tests/test_crd_ids.py
+++ b/tests/test_crd_ids.py
@@ -111,7 +111,7 @@ def test_generate_crd_ids_optional_canonical_columns_disambiguate_coordinates():
     assert result["CRD_ID"].is_unique
 
 
-def test_generate_crd_ids_collide_when_all_available_canonical_values_match(caplog):
+def test_generate_crd_ids_drop_duplicate_canonical_rows(caplog):
     frame = dd.from_pandas(
         pd.DataFrame(
             {
@@ -130,13 +130,14 @@ def test_generate_crd_ids_collide_when_all_available_canonical_values_match(capl
         sort=False,
     )
 
-    result = _generate_crd_ids(frame, "314_example", "/tmp")
+    caplog.set_level(logging.WARNING)
+    result = _generate_crd_ids(
+        frame, "314_example", "/tmp", logger=logging.getLogger(__name__)
+    )
+    computed = result.compute()
 
-    caplog.set_level(logging.ERROR)
-    with pytest.raises(RuntimeError, match="non-unique CRD_ID"):
-        _validate_unique_crd_ids(result, "314_example", logging.getLogger(__name__))
+    assert len(computed) == 1
+    assert computed["CRD_ID"].is_unique
+    _validate_unique_crd_ids(result, "314_example", logging.getLogger(__name__))
 
-    assert "CRD_ID collision diagnostics" in caplog.text
-    assert "duplicate_rows=1" in caplog.text
-    assert "sample_groups=" in caplog.text
-    assert "sample_rows=" in caplog.text
+    assert "dropped 1 duplicate canonical input row(s)" in caplog.text

--- a/tests/test_dedup_partition_safety.py
+++ b/tests/test_dedup_partition_safety.py
@@ -89,7 +89,7 @@ def test_reference_radius_split_is_stable_across_main_margin_views():
     assert second.loc["D", "group_id"] != first.loc["A", "group_id"]
 
 
-def test_custom_priority_keeps_excluded_star_outside_graph():
+def test_custom_priority_considers_star_after_preparation_filters_have_run():
     rows = [
         {
             **_row("A", "B, S", 10.0, 4.0),
@@ -114,9 +114,8 @@ def test_custom_priority_keeps_excluded_star_outside_graph():
         group_col="group_id",
     ).set_index("CRD_ID")
 
-    assert result["tie_result"].astype(int).to_dict() == {"A": 0, "B": 1, "S": 3}
-    assert result.loc["A", "group_id"] == result.loc["B", "group_id"]
-    assert result.loc["S", "group_id"] != result.loc["B", "group_id"]
+    assert result["tie_result"].astype(int).to_dict() == {"A": 0, "B": 0, "S": 1}
+    assert result["group_id"].nunique() == 1
 
 
 def test_local_invariant_accepts_single_winner_and_hard_tie():
@@ -124,7 +123,7 @@ def test_local_invariant_accepts_single_winner_and_hard_tie():
         {
             "group_id": [1, 1, 2, 2, 3],
             "z_flag_homogenized": [4, 3, 4, 4, pd.NA],
-            "tie_result": [1, 0, 2, 2, 3],
+            "tie_result": [1, 0, 2, 2, 1],
         }
     )
 
@@ -205,7 +204,7 @@ def test_global_tie_validation_detects_invalid_patterns():
             {
                 "group_id": [1, 1, 2, 2, 3, 3, 4],
                 "z_flag_homogenized": [4, 3, 4, 4, 4, 4, pd.NA],
-                "tie_result": [1, 0, 2, 2, 1, 1, 3],
+                "tie_result": [1, 0, 2, 2, 1, 1, 1],
             }
         ),
         npartitions=2,
@@ -226,7 +225,7 @@ def test_global_tie_validation_accepts_compact_labels_without_z_flag():
         pd.DataFrame(
             {
                 "group_id": [1, 1, 2, 2, 3],
-                "tie_result": [1, 0, 2, 2, 3],
+                "tie_result": [1, 0, 2, 2, 1],
             }
         ),
         npartitions=2,

--- a/tests/test_deduplication_core.py
+++ b/tests/test_deduplication_core.py
@@ -80,7 +80,7 @@ def test_full_dedup_emits_two_and_three_way_hard_ties():
     assert three_way["group_id"].nunique() == 1
 
 
-def test_excluded_stars_are_isolated_from_deduplication():
+def test_stars_participate_after_preparation_filters_have_run():
     result = _deduplicate(
         [
             _row("A", "S", flag=4),
@@ -89,8 +89,8 @@ def test_excluded_stars_are_isolated_from_deduplication():
         ]
     )
 
-    assert result["tie_result"].astype(int).to_dict() == {"A": 1, "S": 3, "B": 1}
-    assert result["group_id"].nunique() == 3
+    assert result["tie_result"].astype(int).to_dict() == {"A": 1, "S": 0, "B": 0}
+    assert result["group_id"].nunique() == 1
 
 
 def test_connected_components_are_transitive():
@@ -141,7 +141,7 @@ def test_singleton_and_dangling_neighbor_remain_winners():
     assert result["group_id"].nunique() == 2
 
 
-def test_catalog_containing_only_stars_keeps_each_star_isolated():
+def test_catalog_containing_only_stars_does_not_emit_tie_result_three():
     result = _deduplicate(
         [
             _row("S1", "S2", flag=None, object_type="star"),
@@ -149,8 +149,8 @@ def test_catalog_containing_only_stars_keeps_each_star_isolated():
         ]
     )
 
-    assert result["tie_result"].astype(int).to_dict() == {"S1": 3, "S2": 3}
-    assert result["group_id"].nunique() == 2
+    assert result["tie_result"].astype(int).to_dict() == {"S1": 1, "S2": 0}
+    assert result["group_id"].nunique() == 1
 
 
 def test_included_star_without_quality_uses_internal_half_point_score():
@@ -162,7 +162,6 @@ def test_included_star_without_quality_uses_internal_half_point_score():
             ]
         ),
         tiebreaking_priority=["z_flag_homogenized"],
-        object_type_inclusion={"include_star": True},
         delta_z_threshold=0,
     ).set_index("CRD_ID")
 
@@ -179,7 +178,6 @@ def test_internal_half_point_loses_to_real_quality_one():
             ]
         ),
         tiebreaking_priority=["z_flag_homogenized"],
-        object_type_inclusion={"include_star": True},
         delta_z_threshold=0,
     ).set_index("CRD_ID")
 
@@ -187,23 +185,23 @@ def test_internal_half_point_loses_to_real_quality_one():
 
 
 def test_object_type_inclusion_requires_booleans_and_one_enabled_type():
-    with pytest.raises(TypeError, match=r"param\.include_star must be a boolean"):
-        validate_object_type_inclusion({"include_star": "yes"})
+    with pytest.raises(TypeError, match=r"param\.include_star_oth must be a boolean"):
+        validate_object_type_inclusion({"include_star_oth": "yes"})
     with pytest.raises(ValueError, match="At least one"):
         validate_object_type_inclusion(
             {
-                "include_unclassified": False,
-                "include_galaxy": False,
-                "include_star": False,
-                "include_agn": False,
-                "include_qso": False,
-                "include_galactic": False,
+                "include_unclassified_oth": False,
+                "include_galaxy_oth": False,
+                "include_star_oth": False,
+                "include_agn_oth": False,
+                "include_qso_oth": False,
+                "include_galactic_oth": False,
             }
         )
 
 
 @pytest.mark.parametrize("object_type", ["star", "galactic"])
-def test_default_object_type_policy_excludes_stellar_and_galactic(object_type):
+def test_default_object_type_policy_is_no_longer_a_dedup_exclusion(object_type):
     result = _deduplicate(
         [
             _row("X", "G", flag=None, object_type=object_type),
@@ -211,12 +209,12 @@ def test_default_object_type_policy_excludes_stellar_and_galactic(object_type):
         ]
     )
 
-    assert result.loc["X", "tie_result"] == 3
+    assert result.loc["X", "tie_result"] == 0
     assert result.loc["G", "tie_result"] == 1
-    assert result["group_id"].nunique() == 2
+    assert result["group_id"].nunique() == 1
 
 
-def test_unclassified_rows_can_be_excluded_explicitly():
+def test_object_type_inclusion_is_validated_but_not_used_as_dedup_filter():
     result = deduplicate_pandas(
         pd.DataFrame(
             [
@@ -225,12 +223,12 @@ def test_unclassified_rows_can_be_excluded_explicitly():
             ]
         ),
         tiebreaking_priority=["z_flag_homogenized"],
-        object_type_inclusion={"include_unclassified": False},
+        object_type_inclusion={"include_unclassified_oth": False},
         group_col="group_id",
     ).set_index("CRD_ID")
 
-    assert result.loc["U", "tie_result"] == 3
-    assert result.loc["G", "tie_result"] == 1
+    assert result["tie_result"].astype(int).to_dict() == {"U": 2, "G": 2}
+    assert result["group_id"].nunique() == 1
 
 
 def _chain_rows():

--- a/tests/test_homogenization.py
+++ b/tests/test_homogenization.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 import sys
 import types
@@ -16,7 +17,10 @@ if "tables_io" not in sys.modules:
     sys.modules["tables_io"] = tables_io
 
 from specz import (  # noqa: E402
+    _apply_instrument_type_filter,
+    _apply_object_type_filter,
     _normalize_custom_tiebreaking_priorities,
+    _required_homogenized_columns,
     _requires_z_flag_homogenization,
     validate_combine_configuration,
 )
@@ -28,9 +32,144 @@ from specz_homogenization import (
 LOGGER = logging.getLogger("test.homogenization")
 
 
-def test_translation_schema_rejects_unsafe_expression_with_exact_path():
+def _science_config(**overrides):
     config = {
-        "translation_rules": {
+        "tiebreaking_priority": [],
+        "instrument_type_priority": {"s": 3, "g": 2, "p": 1},
+        "expr_column_schema": {},
+        "translation_rules": {"DEMO": {}},
+    }
+    for key, value in overrides.items():
+        if key == "translation_rules":
+            config["translation_rules"] = value
+        else:
+            config[key] = value
+    return config
+
+
+def test_template_expr_schema_covers_standard_translation_expression_columns():
+    root = Path(__file__).resolve().parents[1]
+    translation = yaml.safe_load(
+        (root / "flags_translation.yaml").read_text(encoding="utf-8")
+    )
+    protected = {
+        "id",
+        "ra",
+        "dec",
+        "z",
+        "z_flag",
+        "z_err",
+        "survey",
+        "instrument_type",
+        "object_type",
+    }
+    callables = {"np", "pd", "math", "float", "int", "str", "len"}
+    variables = set()
+    for ruleset in (translation.get("translation_rules") or {}).values():
+        for rule in (ruleset or {}).values():
+            if not isinstance(rule, dict):
+                continue
+            for condition in rule.get("conditions") or []:
+                expr = condition.get("expr")
+                if not expr:
+                    continue
+                tree = ast.parse(expr, mode="eval")
+                variables.update(
+                    node.id
+                    for node in ast.walk(tree)
+                    if isinstance(node, ast.Name)
+                    and node.id not in protected
+                    and node.id not in callables
+                )
+
+    schema = translation.get("expr_column_schema", {})
+    assert variables - set(schema) == set()
+
+
+def test_object_type_filter_removes_disabled_types(tmp_path):
+    ddf = dd.from_pandas(
+        pd.DataFrame(
+            {
+                "CRD_ID": ["G", "S", "U"],
+                "object_type_homogenized": ["galaxy", "star", pd.NA],
+            }
+        ),
+        npartitions=1,
+    )
+
+    filtered, empty = _apply_object_type_filter(
+        ddf,
+        param_config={
+            "include_unclassified_oth": True,
+            "include_galaxy_oth": True,
+            "include_star_oth": False,
+            "include_agn_oth": True,
+            "include_qso_oth": True,
+            "include_galactic_oth": False,
+        },
+        product_name="demo",
+        temp_dir=str(tmp_path),
+        logger=LOGGER,
+    )
+
+    assert not empty
+    assert filtered.compute()["CRD_ID"].tolist() == ["G", "U"]
+
+
+def test_instrument_type_filter_marks_empty_catalog(tmp_path):
+    ddf = dd.from_pandas(
+        pd.DataFrame(
+            {
+                "CRD_ID": ["P1", "P2"],
+                "instrument_type_homogenized": ["p", pd.NA],
+            }
+        ),
+        npartitions=1,
+    )
+
+    filtered, empty = _apply_instrument_type_filter(
+        ddf,
+        param_config={
+            "include_spectroscopic_ith": True,
+            "include_grism_ith": True,
+            "include_photometric_ith": False,
+            "include_unclassified_ith": False,
+        },
+        product_name="demo",
+        temp_dir=str(tmp_path),
+        logger=LOGGER,
+    )
+
+    assert empty
+    assert filtered.compute().empty
+    assert (tmp_path / "prepared_demo.empty").read_text().startswith(
+        "empty_after_instrument_type_homogenized_filter"
+    )
+
+
+def test_required_homogenized_columns_include_filters_and_priorities():
+    required = _required_homogenized_columns(
+        param_config={
+            "z_flag_homogenized_value_to_cut": 3,
+            "include_photometric_ith": False,
+            "include_star_oth": False,
+        },
+        tiebreaking_priority=["custom_rank", "instrument_type_homogenized"],
+    )
+
+    assert required == {
+        "z_flag_homogenized": ["z_flag_homogenized_value_to_cut"],
+        "instrument_type_homogenized": [
+            "tiebreaking_priority",
+            "instrument_type_filter",
+        ],
+        "object_type_homogenized": ["object_type_filter"],
+    }
+
+
+def test_translation_schema_rejects_unsafe_expression_with_exact_path():
+    config = _science_config(
+        translation_rules={
             "DEMO": {
                 "object_type_translation": {
                     "conditions": [
@@ -39,7 +178,7 @@ def test_translation_schema_rejects_unsafe_expression_with_exact_path():
                 }
             }
         }
-    }
+    )
 
     with pytest.raises(
         ValueError,
@@ -49,20 +188,20 @@ def test_translation_schema_rejects_unsafe_expression_with_exact_path():
 
 
 def test_translation_schema_rejects_private_attributes_and_typos():
-    private = {
-        "translation_rules": {
+    private = _science_config(
+        translation_rules={
             "DEMO": {
                 "object_type_translation": {
                     "conditions": [{"expr": "value.__class__", "value": "star"}]
                 }
             }
         }
-    }
+    )
     with pytest.raises(ValueError, match="private attribute"):
         validate_translation_config(private)
 
-    typo = {
-        "translation_rules": {
+    typo = _science_config(
+        translation_rules={
             "DEMO": {
                 "object_type_translation": {
                     "allow_condition_overlaps": True,
@@ -70,51 +209,60 @@ def test_translation_schema_rejects_private_attributes_and_typos():
                 }
             }
         }
-    }
+    )
     with pytest.raises(ValueError, match="did you mean 'allow_condition_overlap'"):
         validate_translation_config(typo)
 
 
 def test_translation_schema_validates_output_domains_and_condition_shape():
-    invalid_value = {
-        "translation_rules": {
+    invalid_value = _science_config(
+        translation_rules={
             "DEMO": {"z_flag_translation": {"default": 9}}
         }
-    }
+    )
     with pytest.raises(ValueError, match=r"z_flag_translation\.default=9"):
         validate_translation_config(invalid_value)
 
-    invalid_condition = {
-        "translation_rules": {
+    invalid_condition = _science_config(
+        translation_rules={
             "DEMO": {
                 "object_type_translation": {
                     "conditions": [{"expr": "value == 1", "vale": "star"}]
                 }
             }
         }
-    }
+    )
     with pytest.raises(ValueError, match=r"conditions\[0\].*unknown option"):
         validate_translation_config(invalid_condition)
 
 
 def test_translation_schema_validates_diagnostic_controls():
     with pytest.raises(TypeError, match="tie_invariant_diagnostics_enabled"):
-        validate_translation_config({"tie_invariant_diagnostics_enabled": "yes"})
+        validate_translation_config(
+            _science_config(tie_invariant_diagnostics_enabled="yes")
+        )
     with pytest.raises(ValueError, match="tie_invariant_diagnostics_sample_size"):
-        validate_translation_config({"tie_invariant_diagnostics_sample_size": 0})
+        validate_translation_config(
+            _science_config(tie_invariant_diagnostics_sample_size=0)
+        )
     with pytest.raises(ValueError, match="max_representative_radius_arcsec"):
-        validate_translation_config({"max_representative_radius_arcsec": 0})
+        validate_translation_config(_science_config(max_representative_radius_arcsec=0))
 
     validate_translation_config(
-        {
-            "tie_invariant_diagnostics_enabled": True,
-            "tie_invariant_diagnostics_detailed_enabled": False,
-            "tie_invariant_diagnostics_sample_size": 10,
-            "tie_invariant_diagnostics_max_rows": 100,
-            "label_merge_diagnostics_enabled": True,
-            "max_representative_radius_arcsec": 1.0,
-        }
+        _science_config(
+            tie_invariant_diagnostics_enabled=True,
+            tie_invariant_diagnostics_detailed_enabled=False,
+            tie_invariant_diagnostics_sample_size=10,
+            tie_invariant_diagnostics_max_rows=100,
+            label_merge_diagnostics_enabled=True,
+            max_representative_radius_arcsec=1.0,
+        )
     )
+
+
+def test_translation_schema_requires_core_scientific_options():
+    with pytest.raises(ValueError, match="missing required scientific option"):
+        validate_translation_config({})
 
 
 def test_yaml_flag_translation_applies_direct_default_and_condition():
@@ -129,9 +277,9 @@ def test_yaml_flag_translation_applies_direct_default_and_condition():
         npartitions=2,
         sort=False,
     )
-    config = {
-        "tiebreaking_priority": ["z_flag_homogenized"],
-        "translation_rules": {
+    config = _science_config(
+        tiebreaking_priority=["z_flag_homogenized"],
+        translation_rules={
             "DEMO": {
                 "z_flag_translation": {
                     "default": 0,
@@ -140,7 +288,7 @@ def test_yaml_flag_translation_applies_direct_default_and_condition():
                 }
             }
         },
-    }
+    )
 
     result, *_ = _homogenize(frame, config, "demo", LOGGER, type_cast_ok=False)
 
@@ -153,14 +301,14 @@ def test_z_flag_fast_path_policy_can_be_disabled_or_required():
         npartitions=1,
         sort=False,
     )
-    disabled = {
-        "tiebreaking_priority": ["z_flag_homogenized"],
-        "translation_rules": {
+    disabled = _science_config(
+        tiebreaking_priority=["z_flag_homogenized"],
+        translation_rules={
             "DEMO": {
                 "z_flag_translation": {"fast_path": "disabled", "default": 3}
             }
         },
-    }
+    )
     result, *_ = _homogenize(
         frame, disabled, "demo", LOGGER, type_cast_ok=False
     )
@@ -171,14 +319,14 @@ def test_z_flag_fast_path_policy_can_be_disabled_or_required():
         npartitions=1,
         sort=False,
     )
-    required = {
-        "tiebreaking_priority": ["z_flag_homogenized"],
-        "translation_rules": {
+    required = _science_config(
+        tiebreaking_priority=["z_flag_homogenized"],
+        translation_rules={
             "DEMO": {
                 "z_flag_translation": {"fast_path": "required", "default": 3}
             }
         },
-    }
+    )
     with pytest.raises(ValueError, match="fast_path is 'required'"):
         _homogenize(incompatible, required, "demo", LOGGER, type_cast_ok=False)
 
@@ -191,9 +339,9 @@ def test_instrument_fast_path_can_be_disabled():
         npartitions=1,
         sort=False,
     )
-    config = {
-        "tiebreaking_priority": ["instrument_type_homogenized"],
-        "translation_rules": {
+    config = _science_config(
+        tiebreaking_priority=["instrument_type_homogenized"],
+        translation_rules={
             "DEMO": {
                 "instrument_type_translation": {
                     "fast_path": "disabled",
@@ -201,7 +349,7 @@ def test_instrument_fast_path_can_be_disabled():
                 }
             }
         },
-    }
+    )
     result, *_ = _homogenize(frame, config, "demo", LOGGER, type_cast_ok=True)
     assert result.compute()["instrument_type_homogenized"].tolist() == ["p", "p"]
 
@@ -214,8 +362,8 @@ def test_optional_source_absence_keeps_condition_fallback():
         npartitions=1,
         sort=False,
     )
-    config = {
-        "translation_rules": {
+    config = _science_config(
+        translation_rules={
             "DEMO": {
                 "object_type_translation": {
                     "source": "missing_optional_column",
@@ -226,7 +374,7 @@ def test_optional_source_absence_keeps_condition_fallback():
                 }
             }
         }
-    }
+    )
     result, *_ = _homogenize(frame, config, "demo", LOGGER, type_cast_ok=False)
     assert result.compute()["object_type_homogenized"].fillna("missing").tolist() == [
         "galaxy",
@@ -246,8 +394,8 @@ def test_later_condition_wins_and_conflicting_overlap_warns(caplog):
         npartitions=1,
         sort=False,
     )
-    config = {
-        "translation_rules": {
+    config = _science_config(
+        translation_rules={
             "DEMO": {
                 "object_type_translation": {
                     "conditions": [
@@ -258,7 +406,7 @@ def test_later_condition_wins_and_conflicting_overlap_warns(caplog):
                 }
             }
         }
-    }
+    )
 
     with caplog.at_level(logging.WARNING, logger=LOGGER.name):
         result, *_ = _homogenize(
@@ -277,8 +425,8 @@ def test_declared_condition_overlap_does_not_warn(caplog):
         npartitions=1,
         sort=False,
     )
-    config = {
-        "translation_rules": {
+    config = _science_config(
+        translation_rules={
             "DEMO": {
                 "object_type_translation": {
                     "allow_condition_overlap": True,
@@ -290,7 +438,7 @@ def test_declared_condition_overlap_does_not_warn(caplog):
                 }
             }
         }
-    }
+    )
 
     with caplog.at_level(logging.WARNING, logger=LOGGER.name):
         result, *_ = _homogenize(
@@ -339,7 +487,9 @@ def test_object_type_is_always_present_and_may_be_entirely_null():
         sort=False,
     )
 
-    result, *_ = _homogenize(frame, {}, "demo", LOGGER, type_cast_ok=False)
+    result, *_ = _homogenize(
+        frame, _science_config(), "demo", LOGGER, type_cast_ok=False
+    )
 
     computed = result.compute()
     assert "object_type_homogenized" in computed
@@ -358,8 +508,8 @@ def test_object_type_translation_uses_canonical_renamed_z_flag():
         npartitions=1,
         sort=False,
     )
-    config = {
-        "translation_rules": {
+    config = _science_config(
+        translation_rules={
             "DEMO": {
                 "object_type_translation": {
                     "conditions": [
@@ -369,7 +519,7 @@ def test_object_type_translation_uses_canonical_renamed_z_flag():
                 }
             }
         }
-    }
+    )
 
     result, *_ = _homogenize(frame, config, "demo", LOGGER, type_cast_ok=False)
 
@@ -386,7 +536,9 @@ def test_object_type_rejects_values_outside_domain():
         npartitions=1,
         sort=False,
     )
-    result, *_ = _homogenize(valid, {}, "demo", LOGGER, type_cast_ok=False)
+    result, *_ = _homogenize(
+        valid, _science_config(), "demo", LOGGER, type_cast_ok=False
+    )
     assert result.compute()["object_type_homogenized"].tolist() == [
         "star",
         "agn",
@@ -399,7 +551,7 @@ def test_object_type_rejects_values_outside_domain():
         sort=False,
     )
     with pytest.raises(ValueError, match="Invalid values"):
-        _homogenize(invalid, {}, "demo", LOGGER, type_cast_ok=False)
+        _homogenize(invalid, _science_config(), "demo", LOGGER, type_cast_ok=False)
 
 
 def test_catalog_object_type_rules_use_renamed_flags_and_conservative_defaults():
@@ -813,21 +965,26 @@ def test_euclid_optional_source_is_safe_before_column_arrives():
     ]
 
 
-def test_homogenization_requires_translation_for_every_survey():
+def test_required_homogenized_column_allows_missing_survey_coverage():
     frame = dd.from_pandas(
         pd.DataFrame({"survey": ["known", "missing"], "z_flag": [1, 1]}),
         npartitions=1,
         sort=False,
     )
-    config = {
-        "tiebreaking_priority": ["z_flag_homogenized"],
-        "translation_rules": {
+    config = _science_config(
+        tiebreaking_priority=["z_flag_homogenized"],
+        translation_rules={
             "KNOWN": {"z_flag_translation": {"default": 1}}
         },
-    }
+    )
 
-    with pytest.raises(ValueError, match="MISSING"):
-        _homogenize(frame, config, "demo", LOGGER, type_cast_ok=False)
+    result, *_ = _homogenize(frame, config, "demo", LOGGER, type_cast_ok=False)
+
+    computed = result.compute()
+    assert computed["z_flag_homogenized"].astype(float).fillna(-1).tolist() == [
+        1.0,
+        -1.0,
+    ]
 
 
 def test_user_homogenized_values_are_normalized_and_validated():
@@ -836,7 +993,9 @@ def test_user_homogenized_values_are_normalized_and_validated():
         npartitions=1,
         sort=False,
     )
-    config = {"tiebreaking_priority": ["instrument_type_homogenized"]}
+    config = _science_config(
+        tiebreaking_priority=["instrument_type_homogenized"]
+    )
 
     result, *_ = _homogenize(valid, config, "demo", LOGGER, type_cast_ok=False)
     assert result.compute()["instrument_type_homogenized"].tolist() == ["s", "g", "p"]
@@ -856,7 +1015,7 @@ def test_user_homogenized_flag_rejects_values_outside_domain():
         npartitions=1,
         sort=False,
     )
-    config = {"tiebreaking_priority": ["z_flag_homogenized"]}
+    config = _science_config(tiebreaking_priority=["z_flag_homogenized"])
 
     with pytest.raises(ValueError, match="Invalid values"):
         _homogenize(frame, config, "demo", LOGGER, type_cast_ok=False)
@@ -873,7 +1032,7 @@ def test_quality_flag_rejects_legacy_six_and_accepts_all_null():
         npartitions=1,
         sort=False,
     )
-    config = {"tiebreaking_priority": ["custom_score"]}
+    config = _science_config(tiebreaking_priority=["custom_score"])
 
     with pytest.raises(ValueError, match="Invalid values"):
         _homogenize(
@@ -892,7 +1051,7 @@ def test_quality_flag_rejects_legacy_six_and_accepts_all_null():
     )
     result, *_ = _homogenize(
         all_null,
-        {"tiebreaking_priority": ["z_flag_homogenized"]},
+        _science_config(tiebreaking_priority=["z_flag_homogenized"]),
         "demo",
         LOGGER,
         type_cast_ok=False,

--- a/tests/test_homogenization.py
+++ b/tests/test_homogenization.py
@@ -247,6 +247,33 @@ def test_translation_schema_rejects_operational_controls():
         validate_translation_config(_science_config(repartition_prepared_catalogs=False))
 
 
+def test_homogenize_accepts_runtime_operational_overlays():
+    frame = dd.from_pandas(
+        pd.DataFrame({"survey": ["demo"], "z_flag": [1]}),
+        npartitions=1,
+        sort=False,
+    )
+    config = _science_config(
+        tiebreaking_priority=["z_flag_homogenized"],
+        translation_rules={"DEMO": {"z_flag_translation": {"default": 3}}},
+        crossmatch_geometry_diagnostics_enabled=False,
+        dedup_edge_diagnostics_enabled=False,
+        label_merge_diagnostics_enabled=True,
+        prepared_partition_size="256MB",
+        repartition_prepared_catalogs=False,
+        representative_radius_diagnostics_enabled=False,
+        save_expr_columns=False,
+        tie_invariant_diagnostics_detailed_enabled=False,
+        tie_invariant_diagnostics_enabled=True,
+        tie_invariant_diagnostics_max_rows=100,
+        tie_invariant_diagnostics_sample_size=10,
+    )
+
+    result, *_ = _homogenize(frame, config, "demo", LOGGER, type_cast_ok=False)
+
+    assert result.compute()["z_flag_homogenized"].tolist() == [3.0]
+
+
 def test_translation_schema_validates_spatial_controls():
     with pytest.raises(ValueError, match="max_representative_radius_arcsec"):
         validate_translation_config(_science_config(max_representative_radius_arcsec=0))

--- a/tests/test_homogenization.py
+++ b/tests/test_homogenization.py
@@ -329,6 +329,124 @@ def test_z_flag_fast_path_policy_can_be_disabled_or_required():
         _homogenize(incompatible, required, "demo", LOGGER, type_cast_ok=False)
 
 
+def test_z_flag_fast_path_bypasses_invalid_required_yaml_rule():
+    frame = dd.from_pandas(
+        pd.DataFrame({"survey": ["demo", "demo"], "z_flag": [0.2, 0.95]}),
+        npartitions=1,
+        sort=False,
+    )
+    config = _science_config(
+        tiebreaking_priority=["z_flag_homogenized"],
+        translation_rules={
+            "DEMO": {
+                "z_flag_translation": {
+                    "conditions": [{"expr": "missing_column > 0", "value": 4}],
+                    "default": 0,
+                }
+            }
+        },
+    )
+
+    result, *_ = _homogenize(
+        frame,
+        config,
+        "demo",
+        LOGGER,
+        type_cast_ok=False,
+        require_z_flag_homogenized=True,
+    )
+
+    assert result.compute()["z_flag_homogenized"].tolist() == [1.0, 3.0]
+
+
+def test_user_homogenized_column_bypasses_invalid_required_yaml_rule():
+    frame = dd.from_pandas(
+        pd.DataFrame(
+            {"survey": ["demo"], "z_flag_homogenized": [4.0], "z_flag": [99.0]}
+        ),
+        npartitions=1,
+        sort=False,
+    )
+    config = _science_config(
+        tiebreaking_priority=["z_flag_homogenized"],
+        translation_rules={
+            "DEMO": {
+                "z_flag_translation": {
+                    "source": "missing_source",
+                    1: 4,
+                }
+            }
+        },
+    )
+
+    result, *_ = _homogenize(
+        frame,
+        config,
+        "demo",
+        LOGGER,
+        type_cast_ok=False,
+        require_z_flag_homogenized=True,
+    )
+
+    assert result.compute()["z_flag_homogenized"].tolist() == [4.0]
+
+
+def test_required_yaml_translation_fails_on_missing_source_column():
+    frame = dd.from_pandas(
+        pd.DataFrame({"survey": ["demo"], "z_flag": [99.0]}),
+        npartitions=1,
+        sort=False,
+    )
+    config = _science_config(
+        translation_rules={
+            "DEMO": {
+                "z_flag_translation": {
+                    "source": "missing_source",
+                    1: 4,
+                }
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="Missing source column 'missing_source'"):
+        _homogenize(
+            frame,
+            config,
+            "demo",
+            LOGGER,
+            type_cast_ok=False,
+            require_z_flag_homogenized=True,
+        )
+
+
+def test_required_object_type_yaml_fails_on_invalid_condition():
+    frame = dd.from_pandas(
+        pd.DataFrame({"survey": ["demo"], "object_type": [pd.NA]}),
+        npartitions=1,
+        sort=False,
+    )
+    config = _science_config(
+        translation_rules={
+            "DEMO": {
+                "object_type_translation": {
+                    "conditions": [{"expr": "missing_column == 1", "value": "galaxy"}],
+                    "default": None,
+                }
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="Error evaluating condition"):
+        _homogenize(
+            frame,
+            config,
+            "demo",
+            LOGGER,
+            type_cast_ok=False,
+            require_object_type_homogenized=True,
+        )
+
+
 def test_instrument_fast_path_can_be_disabled():
     frame = dd.from_pandas(
         pd.DataFrame(

--- a/tests/test_homogenization.py
+++ b/tests/test_homogenization.py
@@ -236,25 +236,23 @@ def test_translation_schema_validates_output_domains_and_condition_shape():
         validate_translation_config(invalid_condition)
 
 
-def test_translation_schema_validates_diagnostic_controls():
-    with pytest.raises(TypeError, match="tie_invariant_diagnostics_enabled"):
+def test_translation_schema_rejects_operational_controls():
+    with pytest.raises(ValueError, match="unknown option"):
+        validate_translation_config(_science_config(save_expr_columns=False))
+    with pytest.raises(ValueError, match="unknown option"):
         validate_translation_config(
-            _science_config(tie_invariant_diagnostics_enabled="yes")
+            _science_config(tie_invariant_diagnostics_enabled=True)
         )
-    with pytest.raises(ValueError, match="tie_invariant_diagnostics_sample_size"):
-        validate_translation_config(
-            _science_config(tie_invariant_diagnostics_sample_size=0)
-        )
+    with pytest.raises(ValueError, match="unknown option"):
+        validate_translation_config(_science_config(repartition_prepared_catalogs=False))
+
+
+def test_translation_schema_validates_spatial_controls():
     with pytest.raises(ValueError, match="max_representative_radius_arcsec"):
         validate_translation_config(_science_config(max_representative_radius_arcsec=0))
 
     validate_translation_config(
         _science_config(
-            tie_invariant_diagnostics_enabled=True,
-            tie_invariant_diagnostics_detailed_enabled=False,
-            tie_invariant_diagnostics_sample_size=10,
-            tie_invariant_diagnostics_max_rows=100,
-            label_merge_diagnostics_enabled=True,
             max_representative_radius_arcsec=1.0,
         )
     )

--- a/tests/test_previous_results.py
+++ b/tests/test_previous_results.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import logging
 import sys
+import types
 from pathlib import Path
 
 import dask.dataframe as dd
 import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "packages"))
+if "tables_io" not in sys.modules:
+    tables_io = types.ModuleType("tables_io")
+    tables_io.types = types.SimpleNamespace(PD_DATAFRAME="PD_DATAFRAME")
+    sys.modules["tables_io"] = tables_io
 
 from specz import (  # noqa: E402
     _copy_extra_columns_from_sources,
@@ -175,6 +180,99 @@ def test_missing_extra_column_is_created_with_null_values():
 
     assert result["DELTACHI2"].isna().all()
     assert str(result["DELTACHI2"].dtype) == "double[pyarrow]"
+
+
+def test_homogenized_output_auto_keeps_runtime_used_columns():
+    frame = dd.from_pandas(
+        pd.DataFrame(
+            {
+                "id": ["a"],
+                "z_flag_homogenized": [4.0],
+                "instrument_type_homogenized": ["s"],
+                "object_type_homogenized": ["galaxy"],
+            }
+        ),
+        npartitions=1,
+    )
+
+    result = _select_output_columns(
+        frame,
+        translation_rules_uc={},
+        tiebreaking_priority=[],
+        used_type_fastpath=False,
+        param_config={
+            "z_flag_homogenized_value_to_cut": 3,
+            "include_star_oth": False,
+            "output_homogenized_columns": {
+                "z_flag_homogenized": "auto",
+                "instrument_type_homogenized": "auto",
+                "object_type_homogenized": "auto",
+            },
+        },
+    ).compute()
+
+    assert "z_flag_homogenized" in result.columns
+    assert "object_type_homogenized" in result.columns
+    assert "instrument_type_homogenized" not in result.columns
+
+
+def test_homogenized_output_default_keeps_all_homogenized_columns():
+    frame = dd.from_pandas(
+        pd.DataFrame(
+            {
+                "id": ["a"],
+                "z_flag_homogenized": [4.0],
+                "instrument_type_homogenized": ["s"],
+                "object_type_homogenized": ["galaxy"],
+            }
+        ),
+        npartitions=1,
+    )
+
+    result = _select_output_columns(
+        frame,
+        translation_rules_uc={},
+        tiebreaking_priority=[],
+        used_type_fastpath=False,
+    ).compute()
+
+    assert {
+        "z_flag_homogenized",
+        "instrument_type_homogenized",
+        "object_type_homogenized",
+    }.issubset(result.columns)
+
+
+def test_homogenized_output_always_and_never_override_auto():
+    frame = dd.from_pandas(
+        pd.DataFrame(
+            {
+                "id": ["a"],
+                "z_flag_homogenized": [4.0],
+                "instrument_type_homogenized": ["s"],
+                "object_type_homogenized": ["galaxy"],
+            }
+        ),
+        npartitions=1,
+    )
+
+    result = _select_output_columns(
+        frame,
+        translation_rules_uc={},
+        tiebreaking_priority=["instrument_type_homogenized"],
+        used_type_fastpath=False,
+        param_config={
+            "output_homogenized_columns": {
+                "z_flag_homogenized": "always",
+                "instrument_type_homogenized": "never",
+                "object_type_homogenized": "auto",
+            }
+        },
+    ).compute()
+
+    assert "z_flag_homogenized" in result.columns
+    assert "instrument_type_homogenized" not in result.columns
+    assert "object_type_homogenized" not in result.columns
 
 
 def test_extra_columns_rejects_unsupported_dtype():

--- a/tests/test_publish_verification.py
+++ b/tests/test_publish_verification.py
@@ -47,7 +47,7 @@ def test_verify_publish_artifacts_detects_corrupted_destination_with_checksum(
         )
 
 
-def test_verify_publish_artifacts_basic_uses_metadata_only(tmp_path, monkeypatch):
+def test_verify_publish_artifacts_basic_uses_size_only(tmp_path, monkeypatch):
     crd_run = _load_crd_run_module()
     logger = logging.getLogger("test_publish_basic_verification")
 

--- a/tests/test_publish_verification.py
+++ b/tests/test_publish_verification.py
@@ -26,7 +26,9 @@ def _load_crd_run_module():
     return module
 
 
-def test_verify_publish_artifacts_detects_corrupted_destination(tmp_path):
+def test_verify_publish_artifacts_detects_corrupted_destination_with_checksum(
+    tmp_path,
+):
     crd_run = _load_crd_run_module()
     logger = logging.getLogger("test_publish_verification")
 
@@ -41,7 +43,30 @@ def test_verify_publish_artifacts_detects_corrupted_destination(tmp_path):
         crd_run._verify_publish_artifacts(
             [("tree", str(src), str(dst))],
             logger,
+            integrity_check=crd_run.PUBLISH_INTEGRITY_CHECK_CHECKSUM,
         )
+
+
+def test_verify_publish_artifacts_basic_uses_metadata_only(tmp_path, monkeypatch):
+    crd_run = _load_crd_run_module()
+    logger = logging.getLogger("test_publish_basic_verification")
+
+    src = tmp_path / "source.txt"
+    dst = tmp_path / "published.txt"
+    src.write_text("same size", encoding="utf-8")
+    dst.write_text("same size", encoding="utf-8")
+
+    monkeypatch.setattr(
+        crd_run,
+        "_sha256_file",
+        lambda path: pytest.fail("basic publish verification should not checksum"),
+    )
+
+    crd_run._verify_publish_artifacts(
+        [("file", str(src), str(dst))],
+        logger,
+        integrity_check=crd_run.PUBLISH_INTEGRITY_CHECK_BASIC,
+    )
 
 
 def test_copy_and_verify_publish_artifacts_retries_transient_failure(
@@ -57,11 +82,11 @@ def test_copy_and_verify_publish_artifacts_retries_transient_failure(
     real_verify = crd_run._verify_publish_artifacts
     attempts = {"count": 0}
 
-    def flaky_verify(artifacts, lg):
+    def flaky_verify(artifacts, lg, integrity_check):
         attempts["count"] += 1
         if attempts["count"] == 1:
             raise FileNotFoundError("simulated stale NFS lookup")
-        return real_verify(artifacts, lg)
+        return real_verify(artifacts, lg, integrity_check)
 
     monkeypatch.setattr(crd_run, "_verify_publish_artifacts", flaky_verify)
     monkeypatch.setattr(crd_run.time, "sleep", lambda seconds: None)
@@ -71,7 +96,56 @@ def test_copy_and_verify_publish_artifacts_retries_transient_failure(
         logger,
         max_attempts=3,
         retry_delay_seconds=0,
+        integrity_check=crd_run.PUBLISH_INTEGRITY_CHECK_BASIC,
     )
 
     assert attempts["count"] == 2
     assert dst.read_text(encoding="utf-8") == "published content"
+
+
+def test_runtime_param_config_accepts_publish_integrity_check():
+    crd_run = _load_crd_run_module()
+
+    param_config = crd_run._build_runtime_param_config(
+        {
+            "run": {
+                "combine_type": "concatenate",
+                "tie_treatment_option": "remove_all",
+                "flags_translation_file": "flags_translation.yaml",
+            },
+            "filters": {
+                "z_flag_homogenized_value_to_cut": 0,
+                "instrument_type_homogenized": {
+                    "include_spectroscopic": True,
+                    "include_grism": True,
+                    "include_photometric": True,
+                    "include_unclassified": True,
+                },
+                "object_type_homogenized": {
+                    "include_unclassified": True,
+                    "include_galaxy": True,
+                    "include_star": True,
+                    "include_agn": True,
+                    "include_qso": True,
+                    "include_galactic": True,
+                },
+            },
+            "preparation": {
+                "repartition_prepared_catalogs": False,
+                "prepared_partition_size": "256MB",
+            },
+            "output": {
+                "extra_columns": {},
+                "homogenized_columns": {},
+                "insert_DP1_footprint_flag": False,
+                "insert_rubin_footprint_flag": False,
+                "publish_integrity_check": "checksum",
+            },
+            "diagnostics": {},
+        }
+    )
+
+    assert (
+        param_config["publish_integrity_check"]
+        == crd_run.PUBLISH_INTEGRITY_CHECK_CHECKSUM
+    )

--- a/tests/test_publish_verification.py
+++ b/tests/test_publish_verification.py
@@ -1,0 +1,77 @@
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+if "tables_io" not in sys.modules:
+    tables_io = types.ModuleType("tables_io")
+    tables_io.types = types.SimpleNamespace(PD_DATAFRAME="PD_DATAFRAME")
+    sys.modules["tables_io"] = tables_io
+
+
+def _load_crd_run_module():
+    root = Path(__file__).resolve().parents[1]
+    packages = str(root / "packages")
+    if packages not in sys.path:
+        sys.path.insert(0, packages)
+
+    script = root / "scripts" / "crd-run.py"
+    spec = importlib.util.spec_from_file_location("crd_run_publish_tests", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_verify_publish_artifacts_detects_corrupted_destination(tmp_path):
+    crd_run = _load_crd_run_module()
+    logger = logging.getLogger("test_publish_verification")
+
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    (src / "catalog.parquet").write_bytes(b"expected bytes")
+    (dst / "catalog.parquet").write_bytes(b"corrupted data")
+
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        crd_run._verify_publish_artifacts(
+            [("tree", str(src), str(dst))],
+            logger,
+        )
+
+
+def test_copy_and_verify_publish_artifacts_retries_transient_failure(
+    tmp_path, monkeypatch
+):
+    crd_run = _load_crd_run_module()
+    logger = logging.getLogger("test_publish_retry")
+
+    src = tmp_path / "source.txt"
+    dst = tmp_path / "published" / "source.txt"
+    src.write_text("published content", encoding="utf-8")
+
+    real_verify = crd_run._verify_publish_artifacts
+    attempts = {"count": 0}
+
+    def flaky_verify(artifacts, lg):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise FileNotFoundError("simulated stale NFS lookup")
+        return real_verify(artifacts, lg)
+
+    monkeypatch.setattr(crd_run, "_verify_publish_artifacts", flaky_verify)
+    monkeypatch.setattr(crd_run.time, "sleep", lambda seconds: None)
+
+    crd_run._copy_and_verify_publish_artifacts(
+        [("file", str(src), str(dst))],
+        logger,
+        max_attempts=3,
+        retry_delay_seconds=0,
+    )
+
+    assert attempts["count"] == 2
+    assert dst.read_text(encoding="utf-8") == "published content"


### PR DESCRIPTION
- reorganize param config into run, filters, output, preparation, and diagnostics sections
- add instrument_type_homogenized and object_type_homogenized input filters
- apply homogenized filters during preparation and fail only when all inputs are emptied
- always create homogenized columns internally and add configurable output retention
- remove tie_result=3 participation semantics from deduplication
- move diagnostics/preparation settings out of flags_translation.yaml
- keep scientific translation schema in flags_translation.yaml and require core science keys
- add fallback warnings for optional scientific settings missing from flags_translation.yaml
- preserve legacy flat config compatibility through normalization/migration
- support formatted JSON output from python config.py
- expand tests for filters, homogenized output policy, translation validation, and empty-input handling